### PR TITLE
Revamped account binding flow and messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@
 
             a. Add new redirect url : <ngrok url>/api/v1/auth/oauth
             b. Click save urls
-            c. Add the following scopes : bot, commands, link:read, link:write
+            c. Add the following scopes : bot, commands, link:read, link:write, chat:write:bot
             d. Click save changes
 
         3. Add Bot user 

--- a/server/controllers/__test__/auth.test.js
+++ b/server/controllers/__test__/auth.test.js
@@ -59,7 +59,7 @@ describe("Test Auth controller methods", () => {
       User.findOrCreate = jest.fn(() => Promise.resolve([user, false]));
       slack.sendAuthRequiredMessage = jest.fn(() => Promise.resolve());
 
-      await auth.beginSlackAssociation(slackUserId, slackUsername, teamId);
+      await auth.beginSlackAssociation(slackUserId, teamId);
 
       expect(Team.findOne).toHaveBeenCalledTimes(1);
       expect(User.findOrCreate).toHaveBeenCalledTimes(1);
@@ -74,7 +74,6 @@ describe("Test Auth controller methods", () => {
     "should begin unfurl slack association",
     async done => {
       const userId = "userId";
-      const messageTs = "messageTs";
       const channel = "channel";
       const teamId = "teamId";
       const accessToken = process.env.SLACK_TEAM_TOKEN || "accessToken";
@@ -88,7 +87,6 @@ describe("Test Auth controller methods", () => {
 
       await auth.beginUnfurlSlackAssociation(
         userId,
-        messageTs,
         channel,
         teamId
       );

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -19,6 +19,7 @@
  */
 const Subscription = require("../models").Subscription;
 const User = require("../models").User;
+const AuthMessage = require("../models").AuthMessage;
 const Team = require("../models").Team;
 
 const uuidv1 = require("uuid/v1");
@@ -26,7 +27,6 @@ const Sequelize = require("sequelize");
 
 const dataworld = require("../api/dataworld");
 const slack = require("../api/slack");
-const DW_AUTH_URL = require("../helpers/helper").DW_AUTH_URL;
 
 const Op = Sequelize.Op;
 
@@ -153,7 +153,7 @@ const checkSlackAssociationStatus = async slackId => {
   }
 };
 
-const beginSlackAssociation = async (slackUserId, slackUsername, teamId) => {
+const beginSlackAssociation = async (slackUserId, teamId, channelId) => {
   try {
     let nonce = uuidv1();
     const team = await Team.findOne({ where: { teamId: teamId } });
@@ -173,9 +173,8 @@ const beginSlackAssociation = async (slackUserId, slackUsername, teamId) => {
     const botToken = process.env.SLACK_BOT_TOKEN || team.botAccessToken;
     await slack.sendAuthRequiredMessage(
       botToken,
-      slackUserId,
       nonce,
-      slackUsername
+      channelId
     );
   } catch (error) {
     console.error("Begin slack association error : ", error.message);
@@ -184,7 +183,6 @@ const beginSlackAssociation = async (slackUserId, slackUsername, teamId) => {
 
 const beginUnfurlSlackAssociation = async (
   userId,
-  messageTs,
   channel,
   teamId
 ) => {
@@ -199,17 +197,15 @@ const beginUnfurlSlackAssociation = async (
 
     if (!created) {
       // User record already exits.
-      //update nonce, reauthenticating existing user.
+      // update nonce, reauthenticating existing user.
       user.update({ nonce: nonce }, { fields: ["nonce"] });
     }
 
     const team = await Team.findOne({ where: { teamId: teamId } });
-    const associationUrl = `${DW_AUTH_URL}${nonce}`;
-    const teamAccessToken = process.env.SLACK_TEAM_TOKEN || team.accessToken;
-    slack.startUnfurlAssociation(
-      associationUrl,
-      teamAccessToken,
-      messageTs,
+    const botAccessToken = process.env.SLACK_BOT_TOKEN || team.botAccessToken;
+    await slack.startUnfurlAssociation(
+      nonce,
+      botAccessToken,
       channel
     );
   } catch (error) {
@@ -230,7 +226,11 @@ const completeSlackAssociation = async (req, res) => {
       // Add returned token
       // redirect to success / homepage
       const user = await User.findOne({ where: { nonce: nonce } });
+      const authMessage = await AuthMessage.findOne({ where: { nonce: nonce }});
+      const { channel, ts } = authMessage;
       const dwUserResponse = await dataworld.getActiveDWUser(token);
+
+      await authMessage.destroy();
       await user.update(
         { dwAccessToken: token, dwRefreshToken: refreshToken, dwUserId: dwUserResponse.data.id },
         { fields: ["dwAccessToken", "dwRefreshToken", "dwUserId"] }
@@ -245,7 +245,7 @@ const completeSlackAssociation = async (req, res) => {
       //inform user via slack that authentication was successful
       const team = await Team.findOne({ where: { teamId: user.teamId } });
       const botAccessToken = process.env.SLACK_BOT_TOKEN || team.botAccessToken;
-      await slack.sendCompletedAssociationMessage(botAccessToken, user.slackId);
+      await slack.sendCompletedAssociationMessage(botAccessToken, user.slackId, channel, ts);
     }
   } catch (error) {
     console.error(error);

--- a/server/migrations/20180816030858-create-auth-message.js
+++ b/server/migrations/20180816030858-create-auth-message.js
@@ -1,0 +1,33 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('AuthMessages', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      channel: {
+        type: Sequelize.STRING
+      },
+      nonce: {
+        type: Sequelize.STRING
+      },
+      ts: {
+        type: Sequelize.STRING
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('AuthMessages');
+  }
+};

--- a/server/models/authmessage.js
+++ b/server/models/authmessage.js
@@ -1,5 +1,5 @@
 /*
- * Data.World Slack Application
+ * data.World Slack Application
  * Copyright 2018 data.world, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/server/models/authmessage.js
+++ b/server/models/authmessage.js
@@ -1,0 +1,31 @@
+/*
+ * Data.World Slack Application
+ * Copyright 2018 data.world, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This product includes software developed at
+ * data.world, Inc. (http://data.world/).
+ */
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  var AuthMessage = sequelize.define('AuthMessage', {
+    channel: DataTypes.STRING,
+    nonce: DataTypes.STRING,
+    ts: DataTypes.STRING
+  }, {});
+  AuthMessage.associate = function(models) {
+    // associations can be defined here
+  };
+  return AuthMessage;
+};


### PR DESCRIPTION
* Delete original prompt, post-binding to reflect the new state

* Redesigned link unfurl account binding prompt
<img width="620" alt="screen shot 2018-08-16 at 10 39 33 am" src="https://user-images.githubusercontent.com/8383678/44203402-ab636280-a146-11e8-842b-2b061ac00cf9.png">

* Redesigned slash command account binding prompt 
<img width="554" alt="screen shot 2018-08-16 at 10 39 56 am" src="https://user-images.githubusercontent.com/8383678/44203403-ab636280-a146-11e8-9284-23317d3fa88d.png">

NOTE: We've added a new scope `chat:write:bot`. since merging will auto deploy to master, we should update scopes and permission for our slack apps and reinstall the apps before merging this.
