### PR TITLE
Update Slack LP to Add ToS/PP/Help

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -146,18 +146,34 @@
     </p>
 </div>
 <!--footer-->
-<div class="footer" style="background:#333D49; padding-top:2em; padding-bottom:2em;">
+<div class="footer" style="background:#333D49; padding-top:2em; padding-bottom:1em;">
       
       <div class="container-fluid p-responsive py-6 py-lg-10 text-center container-lg" style="color:#fff;">
           <h1 class="display-4" style="font-family:Lato;">data.world & Slack </h1>
-          <h2 class="lead" style="font-weight: light ">Get updates, expose important link details, and manage your subscriptions quickly and easily</h2>
+          <h2 class="lead" style="font-weight:light">Get updates, expose important link details, and manage your subscriptions quickly and easily</h2>
 
           <div style="padding-top:20px;">
             <a href="https://slack.com/oauth/authorize?client_id=9877701317.347116338023&scope=bot,commands,links:read,links:write,chat:write:bot">
               <img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" />
             </a>
           </div>
-
+          <div class="row" style="padding-top:2em;">
+            <div class="col-sm-2 form-group offset-sm-3">
+              <p style="font-weight:light;">
+              <a href="https://data.world/privacy/" target="_blank" style="color:#fff"> Privacy Policy </a>
+              </p>
+            </div>
+            <div class="col-sm-2 form-group">
+              <p style="font-weight:light;">
+              <a href="https://data.world/terms/" target="_blank" style="color:#fff"> Terms of Service </a>
+              </p>
+            </div>
+            <div class="col-sm-2 form-group">
+              <p style="font-weight:light;">
+              <a href="https://help.data.world/hc/en-us/requests/new" target="_blank" style="color:#fff"> Get Help </a>
+              </p>
+            </div>
+          </div>
 
       </div>
 


### PR DESCRIPTION
Updating the Slack Landing Page to include links to Terms of Service, Privacy Policy, and Help, according to Slack guidelines for submission. All previous changes have been saved/incorporated.