### PR TITLE
Update deprecated API methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ We definitely appreciate pull requests that highlight or reproduce a problem, ev
 
             a. Add new redirect url : <ngrok url>/api/v1/auth/oauth
             b. Click save urls
-            c. Add the following scopes : bot, commands, link:read, link:write, chat:write, im:read, im:write, channels:read, groups:read, groups:write, npim:write
+            c. Add the following scopes : bot, commands, link:read, link:write, chat:write:bot
             d. Click save changes
 
         3. Add Bot user 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ We definitely appreciate pull requests that highlight or reproduce a problem, ev
 
             a. Add new redirect url : <ngrok url>/api/v1/auth/oauth
             b. Click save urls
-            c. Add the following scopes : bot, commands, link:read, link:write, chat:write:bot
+            c. Add the following scopes : bot, commands, link:read, link:write, chat:write, im:read, im:write, channels:read, groups:read, groups:write, npim:write
             d. Click save changes
 
         3. Add Bot user 

--- a/server/api/slack.js
+++ b/server/api/slack.js
@@ -57,16 +57,16 @@ const botBelongsToChannel = async (channelId, botAccessToken) => {
   const type = getChannelType(channelId);
   switch (type) {
     case DM_CHANNEL:
-      const imsRes = await slackBot.im.list();
-      return imsRes.ims.some(channel => channel.id === channelId);
+      const imsRes = await slackBot.conversations.list({ types: 'im' });
+      return imsRes.channels.some(channel => channel.id === channelId);
     case PUBLIC_CHANNEL:
-      const channelsRes = await slackBot.channels.list();
+      const channelsRes = await slackBot.conversations.list();
       return channelsRes.channels.some(
         channel => channel.id === channelId && channel.is_member
       );
     case GROUP_CHANNEL:
-      const groupsRes = await slackBot.groups.list();
-      return groupsRes.groups.some(channel => channel.id === channelId);
+      const groupsRes = await slackBot.conversations.list({ types: 'private_channel' });
+      return groupsRes.channels.some(channel => channel.id === channelId);
     default:
       console.error("Unknown channel type.");
       return;
@@ -93,7 +93,7 @@ const sendResponse = (responseUrl, data) => {
 const sendWelcomeMessage = async (botAccessToken, slackUserId) => {
   try {
     const slackBot = new SlackWebClient(botAccessToken);
-    const botResponse = await slackBot.im.open(slackUserId);
+    const botResponse = await slackBot.conversations.open({ users: slackUserId });
     if (botResponse && botResponse.channel) {
       const dmChannelId = botResponse.channel.id;
       const commandText = process.env.SLASH_COMMAND;
@@ -207,7 +207,7 @@ const startUnfurlAssociation = async (nonce, botAccessToken, channel, slackUserI
 
 const sendCompletedAssociationMessage = async (botAccessToken, slackUserId) => {
   const slackBot = new SlackWebClient(botAccessToken);
-  const botResponse = await slackBot.im.open(slackUserId);
+  const botResponse = await slackBot.conversations.open({ users: slackUserId });
   const dmChannelId = botResponse.channel.id;
   const commandText = process.env.SLASH_COMMAND;
   const attachments = [
@@ -235,7 +235,7 @@ const deleteSlackMessage = async (botAccessToken, channel, ts) => {
 
 const sendHowToUseMessage = async (botAccessToken, slackUserId) => {
   const slackBot = new SlackWebClient(botAccessToken);
-  const botResponse = await slackBot.im.open(slackUserId);
+  const botResponse = await slackBot.conversations.open({ users: slackUserId });
   const dmChannelId = botResponse.channel.id;
   const commandText = process.env.SLASH_COMMAND;
   const attachments = [

--- a/server/api/slack.js
+++ b/server/api/slack.js
@@ -60,6 +60,7 @@ const botBelongsToChannel = async (channelId, botAccessToken) => {
       const imsRes = await slackBot.conversations.list({ types: 'im' });
       return imsRes.channels.some(channel => channel.id === channelId);
     case PUBLIC_CHANNEL:
+      // conversations.list() returns only public channels by default
       const channelsRes = await slackBot.conversations.list();
       return channelsRes.channels.some(
         channel => channel.id === channelId && channel.is_member


### PR DESCRIPTION
## Description

As per https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api, all `channels.*`, `groups.*`, `im.*`, and `mpim.*` API methods need to be converted to `conversations.*` before February 2021.

The new `conversations.*` required some new scopes, which were added.

**Note**: We are using quite an old version of the [Slack Node SDK](https://www.npmjs.com/package/@slack/client), which has been deprecated. Ideally, we would upgrade to the [new version](https://github.com/slackapi/node-slack-sdk), but they format their arguments slightly differently, which would require updating all Slack API calls in the app. In the interest of time, I chose to avoid this for now as the new API methods are still supported in the version we are using.

## Testing

Message me to be added to the test repo I created. Enter `/data.world` in a public channel, a private channel, and a DM with the `data.world` app. You should receive a message from the `data.world` app. This flow goes through the updated methods and makes sure they work.