### PR TITLE
Updates to CONTRIBUTING doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ We definitely appreciate pull requests that highlight or reproduce a problem, ev
     1. Install Postgres : brew install postgres
     2. Start Postgres using : brew services start postgresql
     3. Open postgres shell : psql postgres
-    4. Create database slackapp in postgres : CREATE DATABASE slackapp
+    4. Create database slackapp in postgres : CREATE DATABASE slackapp;
     5. Quit postgres shell : \q
 
 #### 2. Download and configure Ngrok
@@ -159,7 +159,7 @@ We definitely appreciate pull requests that highlight or reproduce a problem, ev
         DW_CLIENT_ID= (client id from the DW Oauth Client created earlier in step 4.)
         DW_CLIENT_SECRET= (client secret from the DW Oauth Client created earlier in step 4.)
         DW_AUTH_BASE_URL=https://data.world/oauth/authorize
-        DW_GET_TOKEN_BASE_URL=https://data.world/oauth
+        DW_GET_TOKEN_BASE_URL=https://data.world/oauth/access_token
         DW_REDIRECT_URI= <ngrok url>/oauth/code_callback
 
     4. Set Other env variables :

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,8 +94,8 @@ We definitely appreciate pull requests that highlight or reproduce a problem, ev
 
 #### 4. Create slack app
 
-    A. Goto https://api.slack.com/apps
-    B. Click create slack app button (positioned top right corner)
+    A. Goto https://api.slack.com/authentication/basics and scroll to the bottom
+    B. Click on the `Create a classic Slack app` button
 
     C. Under features section in the left panel, configure each of the following :
 


### PR DESCRIPTION
The URL in the env variables for getting an oauth access token was incorrect. I believe it's set properly on prod, as oauth is working properly in the production Slack app. But the `/oauth` endpoint doesn't exist in CWA, and associating with a data.world account didn't work unless I changed it to `/oauth/access_token`.

Also added a semicolon in the Postgres instructions to automatically end the line without user input.