### PR TITLE
Add command for generating per-channel webhook URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,8 @@ We definitely appreciate pull requests that highlight or reproduce a problem, ev
 
     4. Set Other env variables :
 
+        SERVER_PUBLIC_HOSTNAME= <ngrok url>
+
         PORT= node server port (defaults to 5000, if you decide to use a different port number, please revisit your ngrok config and ensure it's listening on the same port you've choosen.)
         PG_USERNAME= Postgres username
         PG_PASSWORD= Postgres password

--- a/server/commands/__test__/webhook.test.js
+++ b/server/commands/__test__/webhook.test.js
@@ -1,0 +1,81 @@
+const Channel = require('../../models').Channel
+
+const slack = require('../../api/slack')
+const webhookCommands = require('../../commands/webhook')
+const webhookHelpers = require('../../helpers/webhook')
+
+jest.mock('../../api/slack')
+
+const buildWebhookUrlSpy = jest.spyOn(webhookHelpers, 'buildWebhookUrl')
+const generateWebhookIdSpy = jest.spyOn(webhookHelpers, 'generateWebhookId')
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('Test webhook command methods', () => {
+  describe('getOrCreateWebhookForChannel', () => {
+    const mockChannelId = 'mockChannelId'
+    const mockResponseUrl = 'mockResponseUrl'
+    const mockWebhookId = 'mockWebhookId'
+    const mockWebhookUrl = `webhook.com/${mockWebhookId}`
+
+    it('should send a response to the responseUrl containing the webhook url', async () => {
+      Channel.findOne = jest.fn(() => Promise.resolve({ webhookId: mockWebhookId }))
+      buildWebhookUrlSpy.mockImplementationOnce(() => mockWebhookUrl)
+
+      await webhookCommands.getOrCreateWebhookForChannel(
+        mockChannelId,
+        mockResponseUrl
+      )
+
+      expect(slack.sendResponse).toHaveBeenCalledWith(
+        mockResponseUrl,
+        { text: expect.stringContaining(mockWebhookUrl) }
+      )
+    })
+
+    describe('when a channel does have an existing webhook id', () => {
+      const existingWebhookId = 'existingWebhookId'
+
+      beforeEach(() => {
+        Channel.findOne = jest.fn(() => ({ webhookId: existingWebhookId }))
+      })
+
+      it('should use the channel\'s existing webhook id if available', async () => {
+        await webhookCommands.getOrCreateWebhookForChannel(
+          mockChannelId,
+          mockResponseUrl
+        )
+
+        expect(slack.sendResponse).toHaveBeenCalledWith(
+          mockResponseUrl,
+          { text: expect.stringContaining(existingWebhookId) }
+        )
+      })
+    })
+
+    describe('when a channel does not have an existing webhook id', () => {
+      const newWebhookId = 'newWebhookId'
+
+      beforeEach(() => {
+        Channel.findOne = jest.fn(() => Promise.resolve({}))
+        Channel.update = jest.fn(() => Promise.resolve())
+        generateWebhookIdSpy.mockImplementationOnce(() => newWebhookId)
+      })
+
+      it('should generate a new webhook id and update the database', async () => {
+        await webhookCommands.getOrCreateWebhookForChannel(
+          mockChannelId,
+          mockResponseUrl
+        )
+
+        expect(Channel.update).toHaveBeenCalled()
+        expect(slack.sendResponse).toHaveBeenCalledWith(
+          mockResponseUrl,
+          { text: expect.stringContaining(newWebhookId) }
+        )
+      })
+    })
+  })
+})

--- a/server/commands/webhook.js
+++ b/server/commands/webhook.js
@@ -1,0 +1,30 @@
+const Channel = require('../models').Channel;
+
+const slack = require('../api/slack')
+const webhookHelper = require('../helpers/webhook')
+
+const getOrCreateWebhookForChannel = async (channelId, responseUrl) => {
+  const channel = await Channel.findOne({
+    where: { channelId }
+  })
+
+  if (channel.webhookId) {
+    webhookId = channel.webhookId
+  } else {
+    webhookId = webhookHelper.generateWebhookId();
+    await Channel.update(
+      { webhookId },
+      { where: { channelId } }
+    )
+  }
+
+  slack.sendResponse(responseUrl, {
+    text: `The webhook URL for this channel is \`${
+      webhookHelper.buildWebhookUrl(webhookId)
+    }\``
+  })
+}
+
+module.exports = {
+  getOrCreateWebhookForChannel
+}

--- a/server/commands/webhook.js
+++ b/server/commands/webhook.js
@@ -8,6 +8,7 @@ const getOrCreateWebhookForChannel = async (channelId, responseUrl) => {
     where: { channelId }
   })
 
+  let webhookId
   if (channel.webhookId) {
     webhookId = channel.webhookId
   } else {

--- a/server/configs/config.json
+++ b/server/configs/config.json
@@ -3,6 +3,7 @@
     "username": "PG_USERNAME",
     "password": "PG_PASSWORD",
     "database": "PG_DATABASE",
+    "dialect": "postgres",
     "options": {
       "host": "127.0.0.1",
       "dialect": "postgres",

--- a/server/controllers/__test__/command.test.js
+++ b/server/controllers/__test__/command.test.js
@@ -534,7 +534,8 @@ describe("Test Auth controller methods", () => {
         `_Unsubscribe from a data.world dataset:_ \n \`/${commandText} unsubscribe dataset_url\``,
         `_Unsubscribe from a data.world project:_ \n \`/${commandText} unsubscribe project_url\``,
         `_Unsubscribe from a data.world account:_ \n \`/${commandText} unsubscribe account\``,
-        `_List active subscriptions._ : \n \`/${commandText} list\``
+        `_List active subscriptions._ : \n \`/${commandText} list\``,
+        `_Get a webhook URL for the current channel:_ \n \`/${commandText} webhook\``
     ];
 
     collection.forEach(commandsInfo, value => {

--- a/server/controllers/command.js
+++ b/server/controllers/command.js
@@ -30,6 +30,7 @@ const auth = require("./auth");
 const dataworld = require("../api/dataworld");
 const helper = require("../helpers/helper");
 const slack = require("../api/slack");
+const webhookCommands = require("../commands/webhook");
 
 // data.world command format
 const commandText = process.env.SLASH_COMMAND;
@@ -39,6 +40,10 @@ const dwCommandRegex = new RegExp(
 );
 const dwSupportCommandRegex = new RegExp(
   `^((\\\/${commandText})(list|help))$`,
+  "i"
+);
+const dwWebhookCommandRegex = new RegExp(
+  `^((\\\/${commandText})(webhook))$`,
   "i"
 );
 
@@ -381,7 +386,7 @@ const listSubscription = async (
     let baseUrl = "https://data.world";
 
     if (!lang.isEmpty(subscriptions)) {
-      message = `*Active Subscriptions*`;
+      message = "*Active Subscriptions*";
       let attachmentText = "";
       await Promise.all(
         subscriptions.map(async subscription => {
@@ -451,7 +456,7 @@ const listSubscription = async (
               options: options,
               confirm: {
                 title: "Confirm",
-                text: `Are you sure you want to unsubscribe from selected resource ?`,
+                text: "Are you sure you want to unsubscribe from selected resource ?",
                 ok_text: "Yes",
                 dismiss_text: "No"
               }
@@ -840,6 +845,11 @@ const validateAndProcessCommand = async (req, res, next) => {
               req.body.channel_id,
               req.body.user_id,
               false
+            );
+          } else if (dwWebhookCommandRegex.test(req.body.command + option)) {
+            webhookCommands.getOrCreateWebhookForChannel(
+              req.body.channel_id,
+              req.body.response_url
             );
           } else {
             // Show help if there's no match found.

--- a/server/controllers/command.js
+++ b/server/controllers/command.js
@@ -623,7 +623,8 @@ const showHelp = async responseUrl => {
     `_Unsubscribe from a data.world dataset:_ \n \`/${commandText} unsubscribe dataset_url\``,
     `_Unsubscribe from a data.world project:_ \n \`/${commandText} unsubscribe project_url\``,
     `_Unsubscribe from a data.world account:_ \n \`/${commandText} unsubscribe account\``,
-    `_List active subscriptions._ : \n \`/${commandText} list\``
+    `_List active subscriptions._ : \n \`/${commandText} list\``,
+    `_Get a webhook URL for the current channel:_ \n \`/${commandText} webhook\``
   ];
 
   collection.forEach(commandsInfo, value => {

--- a/server/helpers/webhook.js
+++ b/server/helpers/webhook.js
@@ -1,0 +1,15 @@
+const uuidv4 = require('uuid/v4')
+
+const buildWebhookUrl = (webhookId) => {
+  return `${process.env.SERVER_PUBLIC_HOSTNAME}/api/v1/webhook/${webhookId}`
+}
+
+const generateWebhookId = () => {
+  // uuidv4 is used to create a random nonce as the webhookId
+  return uuidv4()
+}
+
+module.exports = {
+  buildWebhookUrl,
+  generateWebhookId
+}

--- a/server/migrations/20201208211441-add-webhook-id-column-to-channels-model.js
+++ b/server/migrations/20201208211441-add-webhook-id-column-to-channels-model.js
@@ -1,0 +1,19 @@
+"use strict";
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn(
+      "Channels",
+      "webhookId",
+      Sequelize.STRING
+    );
+  },
+
+  down: (queryInterface, Sequelize) => {
+    queryInterface.removeColumn(
+      "Channels",
+      "webhookId",
+      Sequelize.STRING
+    );
+  }
+};

--- a/server/models/channel.js
+++ b/server/models/channel.js
@@ -24,7 +24,8 @@ module.exports = (sequelize, DataTypes) => {
     {
       channelId: DataTypes.STRING,
       slackUserId: DataTypes.STRING,
-      teamId: DataTypes.STRING
+      teamId: DataTypes.STRING,
+      webhookId: DataTypes.STRING
     },
     {}
   );


### PR DESCRIPTION
Running `/data.world webhook` gives the user a webhook URL for the current channel. The webhook URLs have the following format: `{hostname}/api/v1/webhook/{webhookid}`. Webhook ids have a 1-1 relationship with channels, so the Slack app knows which channel to post the message to based off of a webhook id. This webhook id is generated if there is no associated webhook ID for the current channel in the database yet.

<img width="698" alt="Screen Shot 2020-12-09 at 6 17 39 PM" src="https://user-images.githubusercontent.com/30786057/101700325-d924f180-3a4a-11eb-9c05-19da2449db5f.png">

I created a new directory `server/commands/` for files related to commands. The `server/commands/command.js` was getting getting quite large, as it contained the logic for determining which command should run and also the logic on how to execute each command. Right now I've put the `webhook` command logic in this directory - ideally the `subscribe` command logic would be moved there in the future.