### PR TITLE
Handle webhook request events

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@slack/client": "^3.16.0",
+    "@slack/web-api": "^5.14.0",
     "axios": "^0.18.0",
     "axios-retry": "^3.1.1",
     "body-parser": "~1.18.2",

--- a/server/api/slack.js
+++ b/server/api/slack.js
@@ -265,6 +265,11 @@ const sendMessageWithAttachments = (botAccessToken, channelId, attachments) => {
   slackBot.chat.postMessage(channelId, "", { attachments });
 };
 
+const sendMessageWithBlocks = (botAccessToken, channelId, blocks) => {
+  const slackBot = new SlackWebClient(botAccessToken);
+  // slackBot.makeApiCall('chat.postMessage', { channelId, blocks });
+}
+
 module.exports = {
   botBelongsToChannel,
   isDMChannel,
@@ -276,6 +281,7 @@ module.exports = {
   sendCompletedAssociationMessage,
   sendUnfurlAttachments,
   sendMessageWithAttachments,
+  sendMessageWithBlocks,
   dismissAuthRequiredMessage,
   sendHowToUseMessage,
   deleteSlackMessage

--- a/server/controllers/command.js
+++ b/server/controllers/command.js
@@ -30,7 +30,7 @@ const auth = require("./auth");
 const dataworld = require("../api/dataworld");
 const helper = require("../helpers/helper");
 const slack = require("../api/slack");
-const webhookCommands = require("../commands/webhook");
+const webhookCommands = require("./commands/webhook");
 
 // data.world command format
 const commandText = process.env.SLASH_COMMAND;

--- a/server/controllers/command.js
+++ b/server/controllers/command.js
@@ -31,6 +31,7 @@ const dataworld = require("../api/dataworld");
 const helper = require("../helpers/helper");
 const slack = require("../api/slack");
 const webhookCommands = require("./commands/webhook");
+const { getBotAccessTokenForTeam } = require("../helpers/tokens");
 
 // data.world command format
 const commandText = process.env.SLASH_COMMAND;
@@ -765,12 +766,10 @@ const performAction = async (req, res) => {
 const isBotPresent = async (teamId, channelid, slackUserId, responseUrl) => {
   // Check if bot was invited to slack channel
   // channel found, continue and process command
-  const team = await Team.findOne({
-    where: { teamId: teamId }
-  });
+  const token = await getBotAccessTokenForTeam(teamId);
   const isPresent = await slack.botBelongsToChannel(
     channelid,
-    process.env.SLACK_BOT_TOKEN || team.botAccessToken
+    token
   );
 
   if (isPresent) {

--- a/server/controllers/commands/__test__/webhook.test.js
+++ b/server/controllers/commands/__test__/webhook.test.js
@@ -1,10 +1,10 @@
-const Channel = require('../../models').Channel
+const Channel = require('../../../models').Channel
 
-const slack = require('../../api/slack')
-const webhookCommands = require('../../commands/webhook')
-const webhookHelpers = require('../../helpers/webhook')
+const slack = require('../../../api/slack')
+const webhookCommands = require('../webhook')
+const webhookHelpers = require('../../../helpers/webhook')
 
-jest.mock('../../api/slack')
+jest.mock('../../../api/slack')
 
 const buildWebhookUrlSpy = jest.spyOn(webhookHelpers, 'buildWebhookUrl')
 const generateWebhookIdSpy = jest.spyOn(webhookHelpers, 'generateWebhookId')

--- a/server/controllers/commands/webhook.js
+++ b/server/controllers/commands/webhook.js
@@ -1,7 +1,7 @@
-const Channel = require('../models').Channel;
+const Channel = require('../../models').Channel;
 
-const slack = require('../api/slack')
-const webhookHelper = require('../helpers/webhook')
+const slack = require('../../api/slack')
+const webhookHelper = require('../../helpers/webhook')
 
 const getOrCreateWebhookForChannel = async (channelId, responseUrl) => {
   const channel = await Channel.findOne({

--- a/server/controllers/events/requests.js
+++ b/server/controllers/events/requests.js
@@ -3,30 +3,23 @@ const {
   getAuthorizationRequestSlackBlocks,
   getContributionRequestSlackBlocks
 } = require('../../helpers/requests')
+const { getBotAccessTokenForChannel } = require('../../helpers/tokens')
 
-const Team = require('../../models').Team
-const Channel = require('../../models').Channel
-
-const sendEventToSlack = async (channelIds, blocks) => {
-  // TODO: make helper for getting token
+const sendRequestEventToSlack = async (channelIds, blocks) => {
   for (const channelId of channelIds) {
-    console.log({ channelId })
-    const channel = await Channel.findOne({ where: { channelId: channelId } });
-    const teamId = channel.teamId
-    const team = await Team.findOne({ where: { teamId: teamId } });
-    const token = process.env.SLACK_BOT_TOKEN || team.botAccessToken;
+    const token = await getBotAccessTokenForChannel(channelId)
     slack.sendMessageWithBlocks(token, channelId, blocks)
   }
 }
 
 const handleAuthorizationRequest = async (body, channelIds) => {
   const blocks = getAuthorizationRequestSlackBlocks(body)
-  await sendEventToSlack(channelIds, blocks)
+  await sendRequestEventToSlack(channelIds, blocks)
 }
 
 const handleContributionRequest = async (body, channelIds) => {
   const blocks = getContributionRequestSlackBlocks(body)
-  await sendEventToSlack(channelIds, blocks)
+  await sendRequestEventToSlack(channelIds, blocks)
 }
 
 module.exports = {

--- a/server/controllers/events/requests.js
+++ b/server/controllers/events/requests.js
@@ -1,0 +1,35 @@
+const slack = require('../../api/slack')
+const {
+  getAuthorizationRequestSlackBlocks,
+  getContributionRequestSlackBlocks
+} = require('../../helpers/requests')
+
+const Team = require('../../models').Team
+const Channel = require('../../models').Channel
+
+const sendEventToSlack = async (channelIds, blocks) => {
+  // TODO: make helper for getting token
+  for (const channelId of channelIds) {
+    console.log({ channelId })
+    const channel = await Channel.findOne({ where: { channelId: channelId } });
+    const teamId = channel.teamId
+    const team = await Team.findOne({ where: { teamId: teamId } });
+    const token = process.env.SLACK_BOT_TOKEN || team.botAccessToken;
+    slack.sendMessageWithBlocks(token, channelId, blocks)
+  }
+}
+
+const handleAuthorizationRequest = async (body, channelIds) => {
+  const blocks = getAuthorizationRequestSlackBlocks(body)
+  await sendEventToSlack(channelIds, blocks)
+}
+
+const handleContributionRequest = async (body, channelIds) => {
+  const blocks = getContributionRequestSlackBlocks(body)
+  await sendEventToSlack(channelIds, blocks)
+}
+
+module.exports = {
+  handleAuthorizationRequest,
+  handleContributionRequest
+}

--- a/server/controllers/webhook.js
+++ b/server/controllers/webhook.js
@@ -19,7 +19,6 @@
  */
 const Channel = require("../models").Channel;
 const Subscription = require("../models").Subscription;
-const Team = require("../models").Team;
 const User = require("../models").User;
 
 const array = require("lodash/array");
@@ -32,13 +31,14 @@ const {
   handleAuthorizationRequest,
   handleContributionRequest
 } = require("./events/requests")
-const {
-  DATASET_AUTHORIZATION_TYPES,
-  CONTRIBUTION_REQUEST_TYPES
-} = require("../helpers/requests")
 const dataworld = require("../api/dataworld");
 const slack = require("../api/slack");
 const helper = require("../helpers/helper");
+const {
+  DATASET_AUTHORIZATION_TYPES,
+  CONTRIBUTION_REQUEST_TYPES
+} = require("../helpers/requests");
+const { getBotAccessTokenForTeam } = require("../helpers/tokens");
 
 // Possible event actions
 const CREATE = "create";
@@ -696,8 +696,7 @@ const sendEventToSlack = async (channelIds, attachment) => {
 };
 
 const sendSlackMessage = async (channelId, attachment, teamId) => {
-  const team = await Team.findOne({ where: { teamId: teamId } });
-  const token = process.env.SLACK_BOT_TOKEN || team.botAccessToken;
+  const token = await getBotAccessTokenForTeam(teamId)
   slack.sendMessageWithAttachments(token, channelId, [attachment]);
 };
 

--- a/server/controllers/webhook.js
+++ b/server/controllers/webhook.js
@@ -28,6 +28,14 @@ const lang = require("lodash/lang");
 const pretty = require("prettysize");
 const moment = require("moment");
 
+const {
+  handleAuthorizationRequest,
+  handleContributionRequest
+} = require("./events/requests")
+const {
+  DATASET_AUTHORIZATION_TYPES,
+  CONTRIBUTION_REQUEST_TYPES
+} = require("../helpers/requests")
 const dataworld = require("../api/dataworld");
 const slack = require("../api/slack");
 const helper = require("../helpers/helper");
@@ -694,7 +702,7 @@ const sendSlackMessage = async (channelId, attachment, teamId) => {
 };
 
 const webhook = {
-  async process(req, res) {
+  async processSubscriptionEvent(req, res) {
     try {
       const event = lang.isArray(req.body) ? req.body[0] : req.body;
       // process event based on type
@@ -771,7 +779,38 @@ const webhook = {
         console.warn("No subscriptions found for event.");
       }
     } catch (error) {
-      console.error("Failed to process webhook event! : ", error.message);
+      console.error("Failed to process subscription event! : ", error.message);
+    }
+  },
+
+  async processWebhookEvent(req, res) {
+    try {
+      const body = req.body;
+      const webhookId = req.params.webhookId;
+      const eventType = body.eventType;
+
+      const channels = await Channel.findAll({ where: { webhookId } });
+      if (lang.isEmpty(channels)) {
+        const errorMessage = `Could not find webhookId: ${webhookId}`;
+        console.error(errorMessage);
+        res.status(404).send(errorMessage);
+      }
+      const channelIds = collection.map(channels, "channelId");
+
+      if (Object.values(DATASET_AUTHORIZATION_TYPES).includes(eventType)) {
+        handleAuthorizationRequest(body, channelIds);
+      } else if (Object.values(CONTRIBUTION_REQUEST_TYPES).includes(eventType)) {
+        handleContributionRequest(body, channelIds);
+      } else {
+        const errorMessage = `Invalid eventType: ${eventType}`;
+        console.error(errorMessage);
+        res.status(400).send(errorMessage);
+      }
+
+      res.status(200).send();
+    } catch (error) {
+      console.error("Failed to process webhook event : ", error.message);
+      res.status(500).send();
     }
   }
 };

--- a/server/helpers/__test__/__snapshots__/requests.test.js.snap
+++ b/server/helpers/__test__/__snapshots__/requests.test.js.snap
@@ -1,0 +1,221 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`requests helper methods getAuthorizationRequestSlackBlocks should return correctly formatted blocks for authorizations cancelled/rejected 1`] = `
+Array [
+  Object {
+    "elements": Array [
+      Object {
+        "text": "📍 Use Case Org",
+        "type": "mrkdwn",
+      },
+    ],
+    "type": "context",
+  },
+  Object {
+    "text": Object {
+      "text": "_<https://ddw-corewebapp.dev.data.world/patrick|Patrick Star>_ has cancelled their request for _view_ access to _<https://ddw-corewebapp.dev.data.world/use-case-org/use-case-discvoerable|use-case-discvoerable>_",
+      "type": "mrkdwn",
+    },
+    "type": "section",
+  },
+  Object {
+    "type": "divider",
+  },
+  Object {
+    "fields": Array [
+      Object {
+        "text": "*<https://ddw-corewebapp.dev.data.world/patrick|Patrick Star>*
+*User ID*: _patrick_
+*E-mail*: _patrick@star.com_
+",
+        "type": "mrkdwn",
+      },
+      Object {
+        "text": "*<https://ddw-corewebapp.dev.data.world/use-case-org/use-case-discvoerable|use-case-discvoerable>*
+*Resource ID*: _use-case-discvoerable_
+*Owner ID*: _use-case-org_
+",
+        "type": "mrkdwn",
+      },
+    ],
+    "type": "section",
+  },
+  Object {
+    "type": "divider",
+  },
+]
+`;
+
+exports[`requests helper methods getAuthorizationRequestSlackBlocks should return correctly formatted blocks for authorizations created 1`] = `
+Array [
+  Object {
+    "elements": Array [
+      Object {
+        "text": "📍 Use Case Org",
+        "type": "mrkdwn",
+      },
+    ],
+    "type": "context",
+  },
+  Object {
+    "text": Object {
+      "text": "_<https://ddw-corewebapp.dev.data.world/patrick|Patrick Star>_ has requested _view_ access to _<https://ddw-corewebapp.dev.data.world/use-case-org/use-case-discvoerable|use-case-discvoerable>_",
+      "type": "mrkdwn",
+    },
+    "type": "section",
+  },
+  Object {
+    "text": Object {
+      "text": "*Request Details*
+>*How long do you need access to this dataset?*:
+>_6 months_
+>*Any additional notes or comments?*:
+>_I need access._
+>*I am an existing VDAS user*:
+>_Yes_
+",
+      "type": "mrkdwn",
+    },
+    "type": "section",
+  },
+  Object {
+    "text": Object {
+      "text": "*<https://ddw-corewebapp.dev.data.world/use-case-org/use-case-discvoerable/access|Manage this request →>*",
+      "type": "mrkdwn",
+    },
+    "type": "section",
+  },
+  Object {
+    "type": "divider",
+  },
+  Object {
+    "fields": Array [
+      Object {
+        "text": "*<https://ddw-corewebapp.dev.data.world/patrick|Patrick Star>*
+*User ID*: _patrick_
+*E-mail*: _patrick@star.com_
+",
+        "type": "mrkdwn",
+      },
+      Object {
+        "text": "*<https://ddw-corewebapp.dev.data.world/use-case-org/use-case-discvoerable|use-case-discvoerable>*
+*Resource ID*: _use-case-discvoerable_
+*Owner ID*: _use-case-org_
+",
+        "type": "mrkdwn",
+      },
+    ],
+    "type": "section",
+  },
+  Object {
+    "type": "divider",
+  },
+]
+`;
+
+exports[`requests helper methods getContributionRequestSlackBlocks should return correctly formatted blocks for contributions cancelled/rejected 1`] = `
+Array [
+  Object {
+    "elements": Array [
+      Object {
+        "text": "📍 Goo Lagoon",
+        "type": "mrkdwn",
+      },
+    ],
+    "type": "context",
+  },
+  Object {
+    "text": Object {
+      "text": "_<http://localhost:3000/patrick|Patrick Star>_ has removed their suggestions to _<http://localhost:3000/goo-lagoon/catalog/item?uri=https%3A%2F%2Fgoo-lagoon.linked.data.world%2Fd%2Fddw-catalogs%2FbusinessTerm-52ab4c7d-8f88-33e3-b021-0277a37982ef|12th test>_",
+      "type": "mrkdwn",
+    },
+    "type": "section",
+  },
+  Object {
+    "type": "divider",
+  },
+  Object {
+    "fields": Array [
+      Object {
+        "text": "*<http://localhost:3000/patrick|Patrick Star>*
+*User ID*: _patrick_
+*E-mail*: _patrick@star.com_
+",
+        "type": "mrkdwn",
+      },
+      Object {
+        "text": "*<http://localhost:3000/goo-lagoon/catalog/item?uri=https%3A%2F%2Fgoo-lagoon.linked.data.world%2Fd%2Fddw-catalogs%2FbusinessTerm-52ab4c7d-8f88-33e3-b021-0277a37982ef|12th test>*
+*Resource Type*: _Business term_
+",
+        "type": "mrkdwn",
+      },
+    ],
+    "type": "section",
+  },
+  Object {
+    "type": "divider",
+  },
+]
+`;
+
+exports[`requests helper methods getContributionRequestSlackBlocks should return correctly formatted blocks for contributions created 1`] = `
+Array [
+  Object {
+    "elements": Array [
+      Object {
+        "text": "📍 Goo Lagoon",
+        "type": "mrkdwn",
+      },
+    ],
+    "type": "context",
+  },
+  Object {
+    "text": Object {
+      "text": "_<http://localhost:3000/patrick|Patrick Star>_ has suggested changes to _<http://localhost:3000/goo-lagoon/catalog/item?uri=https%3A%2F%2Fgoo-lagoon.linked.data.world%2Fd%2Fddw-catalogs%2FbusinessTerm-52ab4c7d-8f88-33e3-b021-0277a37982ef|12th test>_",
+      "type": "mrkdwn",
+    },
+    "type": "section",
+  },
+  Object {
+    "text": Object {
+      "text": "*Request Details*
+>*Message*:
+>_These are very good changes._
+",
+      "type": "mrkdwn",
+    },
+    "type": "section",
+  },
+  Object {
+    "text": Object {
+      "text": "*<http://localhost:3000/goo-lagoon/catalog/item/approvals?uri=https%3A%2F%2Fgoo-lagoon.linked.data.world%2Fd%2Fddw-catalogs%2FbusinessTerm-52ab4c7d-8f88-33e3-b021-0277a37982ef|Manage this request →>*",
+      "type": "mrkdwn",
+    },
+    "type": "section",
+  },
+  Object {
+    "type": "divider",
+  },
+  Object {
+    "fields": Array [
+      Object {
+        "text": "*<http://localhost:3000/patrick|Patrick Star>*
+*User ID*: _patrick_
+*E-mail*: _patrick@star.com_
+",
+        "type": "mrkdwn",
+      },
+      Object {
+        "text": "*<http://localhost:3000/goo-lagoon/catalog/item?uri=https%3A%2F%2Fgoo-lagoon.linked.data.world%2Fd%2Fddw-catalogs%2FbusinessTerm-52ab4c7d-8f88-33e3-b021-0277a37982ef|12th test>*
+*Resource Type*: _Business term_
+",
+        "type": "mrkdwn",
+      },
+    ],
+    "type": "section",
+  },
+  Object {
+    "type": "divider",
+  },
+]
+`;

--- a/server/helpers/__test__/links.test.js
+++ b/server/helpers/__test__/links.test.js
@@ -1,0 +1,19 @@
+const linksHelpers = require('../links')
+
+describe('links helper methods', () => {
+  describe('getOriginAndPortFromUrl', () => {
+    it('should return the origin with a port if available', () => {
+      const url = 'https://mydomain.com:80/svn/Repos/'
+      expect(linksHelpers.getOriginFromUrl(url)).toEqual(
+        'https://mydomain.com:80'
+      )
+    })
+
+    it('should return the origin without a port if it does not exist', () => {
+      const url = 'https://mydomain.com/svn/Repos/'
+      expect(linksHelpers.getOriginFromUrl(url)).toEqual(
+        'https://mydomain.com'
+      )
+    })
+  })
+})

--- a/server/helpers/__test__/requests.test.js
+++ b/server/helpers/__test__/requests.test.js
@@ -1,0 +1,40 @@
+const requestsHelpers = require('../requests')
+const fixtures = require('../../jest/fixtures')
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('requests helper methods', () => {
+  describe('getAuthorizationRequestSlackBlocks', () => {
+    it('should return correctly formatted blocks for authorizations created', () => {
+      const result = requestsHelpers.getAuthorizationRequestSlackBlocks(
+        fixtures.authorizationRequestCreatedEventBody
+      )
+      expect(result).toMatchSnapshot() 
+    })
+
+    it('should return correctly formatted blocks for authorizations cancelled/rejected', () => {
+      const result = requestsHelpers.getAuthorizationRequestSlackBlocks(
+        fixtures.authorizationRequestCancelledEventBody
+      )
+      expect(result).toMatchSnapshot() 
+    })
+  })
+
+  describe('getContributionRequestSlackBlocks', () => {
+    it('should return correctly formatted blocks for contributions created', () => {
+      const result = requestsHelpers.getContributionRequestSlackBlocks(
+        fixtures.contributionRequestCreatedEventBody
+      )
+      expect(result).toMatchSnapshot() 
+    })
+
+    it('should return correctly formatted blocks for contributions cancelled/rejected', () => {
+      const result = requestsHelpers.getContributionRequestSlackBlocks(
+        fixtures.contributionRequestCancelledEventBody
+      )
+      expect(result).toMatchSnapshot() 
+    })
+  })
+})

--- a/server/helpers/errors.js
+++ b/server/helpers/errors.js
@@ -1,0 +1,9 @@
+class UnreachableCaseError extends Error {
+  constructor(val) {
+    super(`Unreachable case: ${val}`)
+  }
+}
+
+module.exports = {
+  UnreachableCaseError
+}

--- a/server/helpers/links.js
+++ b/server/helpers/links.js
@@ -1,0 +1,12 @@
+function getWebAgentLink(agentid) {
+  return `https://data.world/${agentid}`
+}
+
+function getWebDatasetLink(agentid, datasetid) {
+  return `https://data.world/${agentid}/${datasetid}`
+}
+
+module.exports = {
+  getWebAgentLink,
+  getWebDatasetLink
+}

--- a/server/helpers/links.js
+++ b/server/helpers/links.js
@@ -1,12 +1,18 @@
-function getWebAgentLink(agentid) {
-  return `https://data.world/${agentid}`
+const getOriginFromUrl = (urlString) => {
+  const url = new URL(urlString)
+  return `${url.origin}`
 }
 
-function getWebDatasetLink(agentid, datasetid) {
-  return `https://data.world/${agentid}/${datasetid}`
+const getWebAgentLink = (origin, agentid) => {
+  return `${origin}/${agentid}`
+}
+
+const getWebDatasetLink = (origin, agentid, datasetid) => {
+  return `${origin}/${agentid}/${datasetid}`
 }
 
 module.exports = {
+  getOriginFromUrl,
   getWebAgentLink,
   getWebDatasetLink
 }

--- a/server/helpers/requests.js
+++ b/server/helpers/requests.js
@@ -1,0 +1,371 @@
+const { UnreachableCaseError } = require('./errors')
+const {
+  getWebAgentLink,
+  getWebDatasetLink
+} = require('./links')
+
+const DATASET_AUTHORIZATION_TYPES = {
+  CREATED: 'dataset.authorization.created',
+  DELETED: 'dataset.authorization.deleted',
+  REQUEST_CREATED: 'dataset.authorization_request.created',
+  REQUEST_CANCELLED: 'dataset.authorization_request.cancelled',
+  REQUEST_APPROVED: 'dataset.authorization_request.approved',
+  REQUEST_REJECTED: 'dataset.authorization_request.rejected',
+  INVITE_CREATED: 'dataset.authorization_invite.created',
+  INVITE_CANCELLED: 'dataset.authorization_invite.cancelled',
+  INVITE_APPROVED: 'dataset.authorization_invite.approved',
+  INVITE_REJECTED: 'dataset.authorization_invite.rejected'
+}
+
+const CONTRIBUTION_REQUEST_TYPES = {
+  CATALOG_CONTRIBUTE_CREATED: 'catalog.contribute_request.created',
+  CATALOG_CONTRIBUTE_CANCELLED: 'catalog.contribute_request.cancelled',
+  CATALOG_CONTRIBUTE_APPROVED: 'catalog.contribute_request.approved',
+  CATALOG_TRANSFER_CREATED: 'catalog.transfer_request.created',
+  CATALOG_TRANSFER_CANCELLED: 'catalog.transfer_request.cancelled',
+  CATALOG_TRANSFER_APPROVED: 'catalog.transfer_request.approved',
+  DATASET_CONTRIBUTE_CREATED: 'dataset.contribute_request.created',
+  DATASET_CONTRIBUTE_CANCELLED: 'dataset.contribute_request.cancelled',
+  DATASET_CONTRIBUTE_APPROVED: 'dataset.contribute_request.approved'
+}
+
+function formatLink(text, url) {
+  return `<${url}|${text}>`
+}
+
+function getExtraDetailsText({
+  header,
+  object,
+  headerLink
+}) {
+  const linkedHeader = headerLink
+    ? `*${formatLink(header, headerLink)}*\n`
+    : `*${header}*\n`
+  return Object.entries(object).reduce(
+    (text, [key, val]) => (val ? text + `*${key}*: _${val}_\n` : text),
+    linkedHeader
+  )
+}
+
+function getAuthLevelCopyText(authorizationLevel) {
+  switch (authorizationLevel) {
+    case 'DISCOVER':
+      return 'discover'
+    case 'READ':
+      return 'view'
+    case 'WRITE':
+      return 'edit'
+    case 'ADMIN':
+      return 'manage'
+    default:
+      throw new UnreachableCaseError(authorizationLevel)
+  }
+}
+
+function getDatasetAccessCopyText(
+  authorizationLevel,
+  dataset
+) {
+  return `_${getAuthLevelCopyText(authorizationLevel)}_ access to _${dataset}_`
+}
+
+function hasNonEmptyProperties(object) {
+  return Object.values(object).some(val => val)
+}
+
+function getAuthorizationSummaryText(eventBody) {
+  const grantee =
+    eventBody.granteeType === 'EMAIL'
+      ? formatLink(eventBody.granteeEmail, `mailto:${eventBody.granteeEmail}`)
+      : formatLink(eventBody.granteeName, getWebAgentLink(eventBody.granteeId))
+  const dataset = formatLink(
+    eventBody.resourceName,
+    getWebDatasetLink(eventBody.resourceOwner, eventBody.resourceId)
+  )
+  const actor = formatLink(
+    eventBody.actorName,
+    getWebAgentLink(eventBody.actorId)
+  )
+
+  switch (eventBody.eventType) {
+    case DATASET_AUTHORIZATION_TYPES.CREATED:
+      return `_${grantee}_ has been granted ${getDatasetAccessCopyText(
+        eventBody.authorizationLevel,
+        dataset
+      )} by _${actor}_`
+    case DATASET_AUTHORIZATION_TYPES.DELETED:
+      return `_${grantee}_'s access to _${dataset}_ has been removed by _${actor}_`
+    case DATASET_AUTHORIZATION_TYPES.REQUEST_CREATED:
+      return `_${grantee}_ has requested ${getDatasetAccessCopyText(
+        eventBody.authorizationLevel,
+        dataset
+      )}`
+    case DATASET_AUTHORIZATION_TYPES.REQUEST_CANCELLED:
+      return `_${grantee}_ has cancelled their request for ${getDatasetAccessCopyText(
+        eventBody.authorizationLevel,
+        dataset
+      )}`
+    case DATASET_AUTHORIZATION_TYPES.REQUEST_REJECTED:
+      return `_${grantee}_'s request for ${getDatasetAccessCopyText(
+        eventBody.authorizationLevel,
+        dataset
+      )} has been rejected by _${actor}_`
+    case DATASET_AUTHORIZATION_TYPES.REQUEST_APPROVED:
+      return `_${grantee}_'s request for ${getDatasetAccessCopyText(
+        eventBody.authorizationLevel,
+        dataset
+      )} has been approved by _${actor}_`
+    case DATASET_AUTHORIZATION_TYPES.INVITE_CREATED:
+      return `_${grantee}_ has been invited to have ${getDatasetAccessCopyText(
+        eventBody.authorizationLevel,
+        dataset
+      )} by _${actor}_`
+    case DATASET_AUTHORIZATION_TYPES.INVITE_CANCELLED:
+      return `_${grantee}_'s invite for ${getDatasetAccessCopyText(
+        eventBody.authorizationLevel,
+        dataset
+      )} has been cancelled by _${actor}_`
+    case DATASET_AUTHORIZATION_TYPES.INVITE_REJECTED:
+      return `_${grantee}_ has declined their invitation for ${getDatasetAccessCopyText(
+        eventBody.authorizationLevel,
+        dataset
+      )}`
+    case DATASET_AUTHORIZATION_TYPES.INVITE_APPROVED:
+      return `_${grantee}_ has accepted their invitation for ${getDatasetAccessCopyText(
+        eventBody.authorizationLevel,
+        dataset
+      )}`
+    default:
+      throw new UnreachableCaseError(eventBody)
+  }
+}
+
+function getContributionSummaryText(eventBody) {
+  const requester = formatLink(
+    eventBody.requester.displayName,
+    eventBody.requester.url
+  )
+  const resource = formatLink(eventBody.resource.name, eventBody.resource.url)
+  const actor = formatLink(
+    eventBody.actor.displayName,
+    getWebAgentLink(eventBody.actor.agentid)
+  )
+  switch (eventBody.eventType) {
+    case CONTRIBUTION_REQUEST_TYPES.CATALOG_CONTRIBUTE_CREATED:
+    case CONTRIBUTION_REQUEST_TYPES.DATASET_CONTRIBUTE_CREATED:
+      return `_${requester}_ has suggested changes to _${resource}_`
+    case CONTRIBUTION_REQUEST_TYPES.CATALOG_CONTRIBUTE_CANCELLED:
+    case CONTRIBUTION_REQUEST_TYPES.DATASET_CONTRIBUTE_CANCELLED:
+      return `_${requester}_ has removed their suggestions to _${resource}_`
+    case CONTRIBUTION_REQUEST_TYPES.CATALOG_CONTRIBUTE_APPROVED:
+    case CONTRIBUTION_REQUEST_TYPES.DATASET_CONTRIBUTE_APPROVED:
+      return `_${requester}_'s suggestions to _${resource}_ have been approved by _${actor}_`
+    case CONTRIBUTION_REQUEST_TYPES.CATALOG_TRANSFER_CREATED:
+      return `_${requester}_ has requested to publish _${resource}_`
+    case CONTRIBUTION_REQUEST_TYPES.CATALOG_TRANSFER_CANCELLED:
+      return `_${requester}_ has cancelled their request to publish _${resource}_`
+    case CONTRIBUTION_REQUEST_TYPES.CATALOG_TRANSFER_APPROVED:
+      return `_${requester}_'s request to publish _${resource}_ has been approved by _${actor}_`
+    default:
+      throw new UnreachableCaseError(eventBody)
+  }
+}
+
+function getRequestFormFieldsText(requestFormFields) {
+  return Object.entries(requestFormFields).reduce((text, [key, val]) => {
+    if (key === 'I am an existing VDAS user') {
+      val = val === 'Checked' ? 'Yes' : 'No'
+    }
+    return val ? text + `>*${key}*:\n>_${val}_\n` : text
+  }, '*Request Details*\n')
+}
+
+function getAuthorizationRequestSlackBlocks(eventBody) {
+  const {
+    resourceId,
+    resourceName,
+    resourceOwner,
+    resourceOwnerName
+  } = eventBody
+
+  const detailsBlocks = [
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `📍 ${resourceOwnerName}`
+        }
+      ]
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: getAuthorizationSummaryText(eventBody)
+      }
+    }
+  ]
+
+  if (
+    eventBody.eventType === DATASET_AUTHORIZATION_TYPES.REQUEST_CREATED ||
+    eventBody.eventType === DATASET_AUTHORIZATION_TYPES.INVITE_CREATED
+  ) {
+    if (hasNonEmptyProperties(eventBody.requestFormFields)) {
+      detailsBlocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: getRequestFormFieldsText(eventBody.requestFormFields)
+        }
+      })
+    }
+    detailsBlocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*${formatLink(
+          'Manage this request →',
+          eventBody.resourceAccessUrl
+        )}*`
+      }
+    })
+  }
+
+  const extrasBlocks = [
+    {
+      type: 'section',
+      fields: [
+        {
+          type: 'mrkdwn',
+          text:
+            eventBody.granteeType === 'EMAIL'
+              ? `*${formatLink(
+                  eventBody.granteeEmail,
+                  `mailto:${eventBody.granteeEmail}`
+                )}*\n_User doesn't have a data.world account yet_`
+              : getExtraDetailsText({
+                  header: eventBody.granteeName,
+                  object: {
+                    [eventBody.granteeType === 'USER'
+                      ? 'User ID'
+                      : 'Organization ID']: eventBody.granteeId,
+                    'E-mail': eventBody.granteeEmail
+                  },
+                  headerLink: getWebAgentLink(eventBody.granteeId)
+                })
+        },
+        {
+          type: 'mrkdwn',
+          text: getExtraDetailsText({
+            header: resourceName,
+            object: {
+              'Resource ID': resourceId,
+              'Owner ID': resourceOwner
+            },
+            headerLink: getWebDatasetLink(resourceOwner, resourceId)
+          })
+        }
+      ]
+    }
+  ]
+
+  return [
+    ...detailsBlocks,
+    { type: 'divider' },
+    ...extrasBlocks,
+    { type: 'divider' }
+  ]
+}
+
+function getContributionRequestSlackBlocks(eventBody) {
+  const { org, requester, resource } = eventBody
+
+  const detailsBlocks = [
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `📍 ${org.displayName}`
+        }
+      ]
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: getContributionSummaryText(eventBody)
+      }
+    }
+  ]
+
+  if (
+    eventBody.eventType ===
+      CONTRIBUTION_REQUEST_TYPES.CATALOG_TRANSFER_CREATED ||
+    eventBody.eventType ===
+      CONTRIBUTION_REQUEST_TYPES.CATALOG_CONTRIBUTE_CREATED ||
+    eventBody.eventType ===
+      CONTRIBUTION_REQUEST_TYPES.DATASET_CONTRIBUTE_CREATED
+  ) {
+    if (eventBody.message) {
+      detailsBlocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: getRequestFormFieldsText({ Message: eventBody.message })
+        }
+      })
+    }
+    detailsBlocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*${formatLink(
+          'Manage this request →',
+          eventBody.resource.approvalUrl
+        )}*`
+      }
+    })
+  }
+
+  const extrasBlock = [
+    {
+      type: 'section',
+      fields: [
+        {
+          type: 'mrkdwn',
+          text: getExtraDetailsText({
+            header: requester.displayName,
+            object: { 'User ID': requester.agentid, 'E-mail': requester.email },
+            headerLink: requester.url
+          })
+        },
+        {
+          type: 'mrkdwn',
+          text: getExtraDetailsText({
+            header: resource.name,
+            object: {
+              'Resource Type': resource.type
+            },
+            headerLink: resource.url
+          })
+        }
+      ]
+    }
+  ]
+
+  return [
+    ...detailsBlocks,
+    { type: 'divider' },
+    ...extrasBlock,
+    { type: 'divider' }
+  ]
+}
+
+module.exports = {
+  DATASET_AUTHORIZATION_TYPES,
+  CONTRIBUTION_REQUEST_TYPES,
+  getAuthorizationRequestSlackBlocks,
+  getContributionRequestSlackBlocks
+}

--- a/server/helpers/tokens.js
+++ b/server/helpers/tokens.js
@@ -1,0 +1,18 @@
+const Team = require('../models').Team
+const Channel = require('../models').Channel
+
+const getBotAccessTokenForChannel = async (channelId) => {
+  const channel = await Channel.findOne({ where: { channelId: channelId } })
+  return getBotAccessTokenForTeam(channel.teamId)
+}
+
+const getBotAccessTokenForTeam = async (teamId) => {
+  const team = await Team.findOne({ where: { teamId: teamId } })
+  const token = process.env.SLACK_BOT_TOKEN || team.botAccessToken
+  return token
+}
+
+module.exports = {
+  getBotAccessTokenForChannel,
+  getBotAccessTokenForTeam
+}

--- a/server/jest/fixtures.js
+++ b/server/jest/fixtures.js
@@ -25,6 +25,26 @@ const authorizationRequestCreatedEventBody = {
   requestId: 'a997b017-75a5-4cbb-93b8-02f6242e9483'
 }
 
+const authorizationRequestCancelledEventBody = {
+  actorId: 'patrick',
+  actorName: 'Patrick Star',
+  granteeType: 'USER',
+  granteeEmail: 'patrick@star.com',
+  granteeId: 'patrick',
+  granteeName: 'Patrick Star',
+  resourceId: 'use-case-discvoerable',
+  resourceName: 'use-case-discvoerable',
+  resourceOwner: 'use-case-org',
+  resourceOwnerName: 'Use Case Org',
+  resourceUrl:
+   'https://ddw-corewebapp.dev.data.world/use-case-org/use-case-discvoerable',
+  event:
+   { triggeredBy: 'patrick',
+     created: 'Fri, 11 Dec 2020 03:36:50 GMT' },
+  eventType: 'dataset.authorization_request.cancelled',
+  authorizationLevel: 'READ'
+}
+
 const contributionRequestCreatedEventBody = {
   actor: { agentid: 'patrick', displayName: 'Patrick Star' },
   event:
@@ -48,7 +68,28 @@ const contributionRequestCreatedEventBody = {
   requestId: '21d7ca1c-afa0-4c72-bf9b-8ea03940234f'
 }
 
+const contributionRequestCancelledEventBody = {
+  actor: { agentid: 'patrick', displayName: 'Patrick Star' },
+  event:
+   { created: 'Thu, 10 Dec 2020 23:29:42 GMT',
+     triggeredBy: 'patrick' },
+  org: { agentid: 'goo-lagoon', displayName: 'Goo Lagoon' },
+  requester:
+   { agentid: 'patrick',
+     displayName: 'Patrick Star',
+     email: 'patrick@star.com',
+     url: 'http://localhost:3000/patrick' },
+  resource:
+   { url:
+      'http://localhost:3000/goo-lagoon/catalog/item?uri=https%3A%2F%2Fgoo-lagoon.linked.data.world%2Fd%2Fddw-catalogs%2FbusinessTerm-52ab4c7d-8f88-33e3-b021-0277a37982ef',
+     name: '12th test',
+     type: 'Business term' },
+  eventType: 'catalog.contribute_request.cancelled'
+}
+
 module.exports = {
   authorizationRequestCreatedEventBody,
-  contributionRequestCreatedEventBody
+  authorizationRequestCancelledEventBody,
+  contributionRequestCreatedEventBody,
+  contributionRequestCancelledEventBody
 }

--- a/server/jest/fixtures.js
+++ b/server/jest/fixtures.js
@@ -1,0 +1,54 @@
+const authorizationRequestCreatedEventBody = {
+  actorId: 'patrick',
+  actorName: 'Patrick Star',
+  granteeType: 'USER',
+  granteeEmail: 'patrick@star.com',
+  granteeId: 'patrick',
+  granteeName: 'Patrick Star',
+  resourceId: 'use-case-discvoerable',
+  resourceName: 'use-case-discvoerable',
+  resourceOwner: 'use-case-org',
+  resourceOwnerName: 'Use Case Org',
+  resourceUrl:
+   'https://ddw-corewebapp.dev.data.world/use-case-org/use-case-discvoerable',
+  event:
+   { triggeredBy: 'patrick',
+     created: 'Thu, 10 Dec 2020 23:24:18 GMT' },
+  eventType: 'dataset.authorization_request.created',
+  authorizationLevel: 'READ',
+  resourceAccessUrl:
+   'https://ddw-corewebapp.dev.data.world/use-case-org/use-case-discvoerable/access',
+  requestFormFields:
+   { 'How long do you need access to this dataset?': '6 months',
+     'Any additional notes or comments?': 'I need access.',
+     'I am an existing VDAS user': 'Checked' },
+  requestId: 'a997b017-75a5-4cbb-93b8-02f6242e9483'
+}
+
+const contributionRequestCreatedEventBody = {
+  actor: { agentid: 'patrick', displayName: 'Patrick Star' },
+  event:
+   { created: 'Thu, 10 Dec 2020 23:29:44 GMT',
+     triggeredBy: 'patrick' },
+  org: { agentid: 'goo-lagoon', displayName: 'Goo Lagoon' },
+  requester:
+   { agentid: 'patrick',
+     displayName: 'Patrick Star',
+     email: 'patrick@star.com',
+     url: 'http://localhost:3000/patrick' },
+  resource:
+   { url:
+      'http://localhost:3000/goo-lagoon/catalog/item?uri=https%3A%2F%2Fgoo-lagoon.linked.data.world%2Fd%2Fddw-catalogs%2FbusinessTerm-52ab4c7d-8f88-33e3-b021-0277a37982ef',
+     name: '12th test',
+     type: 'Business term',
+     approvalUrl:
+      'http://localhost:3000/goo-lagoon/catalog/item/approvals?uri=https%3A%2F%2Fgoo-lagoon.linked.data.world%2Fd%2Fddw-catalogs%2FbusinessTerm-52ab4c7d-8f88-33e3-b021-0277a37982ef' },
+  eventType: 'catalog.contribute_request.created',
+  message: 'These are very good changes.',
+  requestId: '21d7ca1c-afa0-4c72-bf9b-8ea03940234f'
+}
+
+module.exports = {
+  authorizationRequestCreatedEventBody,
+  contributionRequestCreatedEventBody
+}

--- a/server/routes/__test__/__snapshots__/webhook.test.js.snap
+++ b/server/routes/__test__/__snapshots__/webhook.test.js.snap
@@ -85,7 +85,7 @@ Array [
       },
       Object {
         "text": Object {
-          "text": "_<https://data.world/patrick|Patrick Star>_ has requested _view_ access to _<https://data.world/use-case-org/use-case-discvoerable|use-case-discvoerable>_",
+          "text": "_<https://ddw-corewebapp.dev.data.world/patrick|Patrick Star>_ has requested _view_ access to _<https://ddw-corewebapp.dev.data.world/use-case-org/use-case-discvoerable|use-case-discvoerable>_",
           "type": "mrkdwn",
         },
         "type": "section",
@@ -117,14 +117,14 @@ Array [
       Object {
         "fields": Array [
           Object {
-            "text": "*<https://data.world/patrick|Patrick Star>*
+            "text": "*<https://ddw-corewebapp.dev.data.world/patrick|Patrick Star>*
 *User ID*: _patrick_
 *E-mail*: _patrick@star.com_
 ",
             "type": "mrkdwn",
           },
           Object {
-            "text": "*<https://data.world/use-case-org/use-case-discvoerable|use-case-discvoerable>*
+            "text": "*<https://ddw-corewebapp.dev.data.world/use-case-org/use-case-discvoerable|use-case-discvoerable>*
 *Resource ID*: _use-case-discvoerable_
 *Owner ID*: _use-case-org_
 ",

--- a/server/routes/__test__/__snapshots__/webhook.test.js.snap
+++ b/server/routes/__test__/__snapshots__/webhook.test.js.snap
@@ -1,0 +1,142 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`POST /api/v1/webhook/:webhookId Should send a slack message for a contribution request event 1`] = `
+Array [
+  Array [
+    "botAccessToken",
+    "mockChannelId",
+    Array [
+      Object {
+        "elements": Array [
+          Object {
+            "text": "📍 Goo Lagoon",
+            "type": "mrkdwn",
+          },
+        ],
+        "type": "context",
+      },
+      Object {
+        "text": Object {
+          "text": "_<http://localhost:3000/patrick|Patrick Star>_ has suggested changes to _<http://localhost:3000/goo-lagoon/catalog/item?uri=https%3A%2F%2Fgoo-lagoon.linked.data.world%2Fd%2Fddw-catalogs%2FbusinessTerm-52ab4c7d-8f88-33e3-b021-0277a37982ef|12th test>_",
+          "type": "mrkdwn",
+        },
+        "type": "section",
+      },
+      Object {
+        "text": Object {
+          "text": "*Request Details*
+>*Message*:
+>_These are very good changes._
+",
+          "type": "mrkdwn",
+        },
+        "type": "section",
+      },
+      Object {
+        "text": Object {
+          "text": "*<http://localhost:3000/goo-lagoon/catalog/item/approvals?uri=https%3A%2F%2Fgoo-lagoon.linked.data.world%2Fd%2Fddw-catalogs%2FbusinessTerm-52ab4c7d-8f88-33e3-b021-0277a37982ef|Manage this request →>*",
+          "type": "mrkdwn",
+        },
+        "type": "section",
+      },
+      Object {
+        "type": "divider",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "text": "*<http://localhost:3000/patrick|Patrick Star>*
+*User ID*: _patrick_
+*E-mail*: _patrick@star.com_
+",
+            "type": "mrkdwn",
+          },
+          Object {
+            "text": "*<http://localhost:3000/goo-lagoon/catalog/item?uri=https%3A%2F%2Fgoo-lagoon.linked.data.world%2Fd%2Fddw-catalogs%2FbusinessTerm-52ab4c7d-8f88-33e3-b021-0277a37982ef|12th test>*
+*Resource Type*: _Business term_
+",
+            "type": "mrkdwn",
+          },
+        ],
+        "type": "section",
+      },
+      Object {
+        "type": "divider",
+      },
+    ],
+  ],
+]
+`;
+
+exports[`POST /api/v1/webhook/:webhookId Should send a slack message for an authorization request event 1`] = `
+Array [
+  Array [
+    "botAccessToken",
+    "mockChannelId",
+    Array [
+      Object {
+        "elements": Array [
+          Object {
+            "text": "📍 Use Case Org",
+            "type": "mrkdwn",
+          },
+        ],
+        "type": "context",
+      },
+      Object {
+        "text": Object {
+          "text": "_<https://data.world/patrick|Patrick Star>_ has requested _view_ access to _<https://data.world/use-case-org/use-case-discvoerable|use-case-discvoerable>_",
+          "type": "mrkdwn",
+        },
+        "type": "section",
+      },
+      Object {
+        "text": Object {
+          "text": "*Request Details*
+>*How long do you need access to this dataset?*:
+>_6 months_
+>*Any additional notes or comments?*:
+>_I need access._
+>*I am an existing VDAS user*:
+>_Yes_
+",
+          "type": "mrkdwn",
+        },
+        "type": "section",
+      },
+      Object {
+        "text": Object {
+          "text": "*<https://ddw-corewebapp.dev.data.world/use-case-org/use-case-discvoerable/access|Manage this request →>*",
+          "type": "mrkdwn",
+        },
+        "type": "section",
+      },
+      Object {
+        "type": "divider",
+      },
+      Object {
+        "fields": Array [
+          Object {
+            "text": "*<https://data.world/patrick|Patrick Star>*
+*User ID*: _patrick_
+*E-mail*: _patrick@star.com_
+",
+            "type": "mrkdwn",
+          },
+          Object {
+            "text": "*<https://data.world/use-case-org/use-case-discvoerable|use-case-discvoerable>*
+*Resource ID*: _use-case-discvoerable_
+*Owner ID*: _use-case-org_
+",
+            "type": "mrkdwn",
+          },
+        ],
+        "type": "section",
+      },
+      Object {
+        "type": "divider",
+      },
+    ],
+  ],
+]
+`;

--- a/server/routes/webhook.js
+++ b/server/routes/webhook.js
@@ -24,6 +24,8 @@ const { webhook } = require("../controllers/webhook");
 const router = express.Router();
 
 /* Listen for DW incomming webhook. */
-router.post("/dw/events", webhook.process);
+router.post("/dw/events", webhook.processSubscriptionEvent);
+
+router.post("/:webhookId", webhook.processWebhookEvent);
 
 module.exports = router;

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,13 +33,52 @@
     winston "^2.1.1"
     ws "^1.0.1"
 
+"@slack/logger@>=1.0.0 <3.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@slack/logger/-/logger-2.0.0.tgz#6a4e1c755849bc0f66dac08a8be54ce790ec0e6b"
+  dependencies:
+    "@types/node" ">=8.9.0"
+
+"@slack/types@^1.7.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-1.10.0.tgz#cbf7d83e1027f4cbfd13d6b429f120c7fb09127a"
+
+"@slack/web-api@^5.14.0":
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-5.14.0.tgz#3c282670f4a5a1d0842b3e1787b46313a3da5d9d"
+  dependencies:
+    "@slack/logger" ">=1.0.0 <3.0.0"
+    "@slack/types" "^1.7.0"
+    "@types/is-stream" "^1.1.0"
+    "@types/node" ">=8.9.0"
+    axios "^0.19.0"
+    eventemitter3 "^3.1.0"
+    form-data "^2.5.0"
+    is-stream "^1.1.0"
+    p-queue "^6.6.1"
+    p-retry "^4.0.0"
+
 "@types/geojson@^1.0.0":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-1.0.6.tgz#3e02972728c69248c2af08d60a48cbb8680fffdf"
 
+"@types/is-stream@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/is-stream/-/is-stream-1.1.0.tgz#b84d7bb207a210f2af9bed431dc0fbe9c4143be1"
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "10.5.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.4.tgz#6eccc158504357d1da91434d75e86acde94bb10b"
+
+"@types/node@>=8.9.0":
+  version "14.14.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.12.tgz#0b1d86f8c40141091285dea02e4940df73bba43f"
+
+"@types/retry@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
 
 abab@^1.0.3, abab@^1.0.4:
   version "1.0.4"
@@ -440,6 +479,12 @@ axios@^0.18.0:
   dependencies:
     follow-redirects "^1.3.0"
     is-buffer "^1.1.5"
+
+axios@^0.19.0:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  dependencies:
+    follow-redirects "1.5.10"
 
 axobject-query@^0.1.0:
   version "0.1.0"
@@ -1729,6 +1774,12 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+combined-stream@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@2.15.x, commander@^2.11.0, commander@~2.15.0:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
@@ -2134,7 +2185,7 @@ debug@2, debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, de
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.1, debug@^3.1.0:
+debug@=3.1.0, debug@^3.0.1, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -2769,6 +2820,14 @@ eventemitter3@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
 
+eventemitter3@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+
+eventemitter3@^4.0.4:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+
 events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -3117,6 +3176,12 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  dependencies:
+    debug "=3.1.0"
+
 follow-redirects@^1.0.0, follow-redirects@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.0.tgz#234f49cf770b7f35b40e790f636ceba0c3a0ab77"
@@ -3147,6 +3212,14 @@ form-data@^2.3.1, form-data@~2.3.1:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "1.0.6"
+    mime-types "^2.1.12"
+
+form-data@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
 form-data@~2.1.1:
@@ -5837,6 +5910,26 @@ p-map@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
 
+p-queue@^6.6.1:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
+  dependencies:
+    eventemitter3 "^4.0.4"
+    p-timeout "^3.2.0"
+
+p-retry@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.2.0.tgz#ea9066c6b44f23cab4cd42f6147cdbbc6604da5d"
+  dependencies:
+    "@types/retry" "^0.12.0"
+    retry "^0.12.0"
+
+p-timeout@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
+  dependencies:
+    p-finally "^1.0.0"
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
@@ -7101,6 +7194,10 @@ retry-as-promised@^2.3.2:
   dependencies:
     bluebird "^3.4.6"
     debug "^2.6.9"
+
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
 
 retry@^0.9.0:
   version "0.9.0"


### PR DESCRIPTION
Most of the diff is from testing/snapshots, it's not actually as bad as it seems.

This change handles webhook requests sent to the generated URLs created in https://github.com/datadotworld/slack-app/pull/43. The general flow is:

1. A request is sent from `notifications` to one of the generated webhooks, with a body containing event details.
2. The Slack app processes this event. It grabs the webhook id from the URL and looks up in the database for the corresponding channel(s).
3. The processing function will delegate to a handler based on `eventType` (currently either authorization or contribution request).
4. The event body will be formatted into Slack blocks, and the message with the blocks are sent to the channel ids.

The `server/helpers/requests.js` file is used to format the body into Slack blocks, and is more or less duplicated from `notifications`, since we don't have a good way of sharing code between the two repos yet.

Currently this doesn't have the interactive buttons implemented yet, the messages mirror what we would normally send from `notifications`. Those will come in a subsequent PR.

<img width="688" alt="Screen Shot 2020-12-10 at 11 37 58 PM" src="https://user-images.githubusercontent.com/30786057/101862644-c391f380-3b40-11eb-8a12-393eb33c722e.png">
