### PR TITLE
Fix isBotPresent bug

### DIFF
--- a/server/controllers/command.js
+++ b/server/controllers/command.js
@@ -766,6 +766,7 @@ const performAction = async (req, res) => {
 const isBotPresent = async (teamId, channelid, slackUserId, responseUrl) => {
   // Check if bot was invited to slack channel
   // channel found, continue and process command
+  const team = await Team.findOne({ where: { teamId: teamId } })
   const token = await getBotAccessTokenForTeam(teamId);
   const isPresent = await slack.botBelongsToChannel(
     channelid,

--- a/server/routes/__test__/command.test.js
+++ b/server/routes/__test__/command.test.js
@@ -211,7 +211,7 @@ describe("POST /api/v1/command/action - Process an action", () => {
           payloadObject.channel.id,
           botAccessToken
         );
-        expect(Team.findOne).toHaveBeenCalledTimes(1);
+        expect(Team.findOne).toHaveBeenCalledTimes(2);
         expect(Channel.findOrCreate).toHaveBeenCalledTimes(1);
         expect(Subscription.destroy).toHaveBeenCalledTimes(1);
         expect(auth.checkSlackAssociationStatus).toBeCalledWith(
@@ -283,7 +283,7 @@ describe("POST /api/v1/command/action - Process an action", () => {
       .expect(200)
       .end((err, res) => {
         if (err) return done(err);
-        expect(Team.findOne).toHaveBeenCalledTimes(1);
+        expect(Team.findOne).toHaveBeenCalledTimes(2);
         expect(Channel.findOrCreate).toHaveBeenCalledTimes(1);
         expect(slack.botBelongsToChannel).toBeCalledWith(
           payloadObject.channel.id,


### PR DESCRIPTION
## Description

I accidentally removed the call to `await Team.findOne({ where: { teamId: teamId } })` in a previous commit where I refactored getting a bot access token into a helper method (https://github.com/datadotworld/slack-app/pull/44/commits/4f0b439e3740c305a9a7cb8ee3ab21aac373543e). It is necessary in the case when a bot is not present in a channel, as it uses the `team` object to get the bot name.