### PR TITLE
Migrate away from classic Slack app

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,8 +94,8 @@ We definitely appreciate pull requests that highlight or reproduce a problem, ev
 
 #### 4. Create slack app
 
-    A. Goto https://api.slack.com/authentication/basics and scroll to the bottom
-    B. Click on the `Create a classic Slack app` button
+    A. Go to https://api.slack.com/start/overview#creating
+    B. Click on the `Create a Slack app` button
 
     C. Under features section in the left panel, configure each of the following :
 
@@ -117,7 +117,7 @@ We definitely appreciate pull requests that highlight or reproduce a problem, ev
 
             a. Add new redirect url : <ngrok url>/api/v1/auth/oauth
             b. Click save urls
-            c. Add the following scopes : bot, commands, link:read, link:write, chat:write:bot
+            c. Add the following scopes : channels:read, chat:write, commands, groups:read, im:history, im:read, im:write, links:read, links:write
             d. Click save changes
 
         3. Add Bot user 

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,8 +21,8 @@
           <h2 class="lead" style="font-weight: light ">Get updates on subscribed data sources and provide insight into shared links</h2>
 
           <div style="padding-top:20px;">
-            <a href="https://slack.com/oauth/authorize?client_id=9877701317.347116338023&scope=bot,commands,links:read,links:write,chat:write:bot">
-              <img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" />
+            <a href="https://slack.com/oauth/v2/authorize?client_id=1508375017543.1545264648997&scope=channels:read,chat:write,commands,groups:read,im:history,im:read,im:write&user_scope=links:read,links:write">
+              <img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcSet="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" />
             </a>
           </div>
 
@@ -173,8 +173,8 @@
           <h2 class="lead" style="font-weight:light">Get updates, expose important link details, and manage your subscriptions quickly and easily</h2>
 
           <div style="padding-top:20px;">
-            <a href="https://slack.com/oauth/authorize?client_id=9877701317.347116338023&scope=bot,commands,links:read,links:write,chat:write:bot">
-              <img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" />
+            <a href="https://slack.com/oauth/v2/authorize?client_id=1508375017543.1545264648997&scope=channels:read,chat:write,commands,groups:read,im:history,im:read,im:write&user_scope=links:read,links:write">
+              <img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcSet="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" />
             </a>
           </div>
           <div class="row" style="padding-top:2em;">

--- a/server/api/__test__/slack.test.js
+++ b/server/api/__test__/slack.test.js
@@ -20,7 +20,7 @@ describe("Test slack api wrapper.", () => {
     slack.oauthAccess(code);
 
     expect(axios.get).toHaveBeenCalledWith(
-      "https://slack.com/api/oauth.access",
+      "https://slack.com/api/oauth.v2.access",
       { headers, params }
     );
 

--- a/server/api/slack.js
+++ b/server/api/slack.js
@@ -83,7 +83,7 @@ const oauthAccess = code => {
     client_secret: process.env.SLACK_CLIENT_SECRET
   };
 
-  return axios.get("https://slack.com/api/oauth.access", {
+  return axios.get("https://slack.com/api/oauth.v2.access", {
     headers,
     params
   });

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -43,12 +43,12 @@ const slackOauth = (req, res) => {
     .then(async response => {
       // create team with returned data
       const [team, created] = await Team.findOrCreate({
-        where: { teamId: response.data.team_id },
+        where: { teamId: response.data.team.id },
         defaults: {
-          teamDomain: response.data.team_name,
-          accessToken: response.data.access_token,
-          botUserId: response.data.bot.bot_user_id,
-          botAccessToken: response.data.bot.bot_access_token
+          teamDomain: response.data.team.name,
+          accessToken: response.data.authed_user.access_token,
+          botUserId: response.data.bot_user_id,
+          botAccessToken: response.data.access_token
         }
       });
       try {
@@ -57,10 +57,10 @@ const slackOauth = (req, res) => {
           // Update existing record with new data
           await team.update(
             {
-              teamDomain: response.data.team_name,
-              accessToken: response.data.access_token,
-              botUserId: response.data.bot.bot_user_id,
-              botAccessToken: response.data.bot.bot_access_token
+              teamDomain: response.data.team.name,
+              accessToken: response.data.authed_user.access_token,
+              botUserId: response.data.bot_user_id,
+              botAccessToken: response.data.access_token
             },
             {
               fields: [
@@ -74,7 +74,7 @@ const slackOauth = (req, res) => {
         }
         //inform user via slack that installation was successful
         const botToken = process.env.SLACK_BOT_TOKEN || team.botAccessToken;
-        await slack.sendWelcomeMessage(botToken, response.data.user_id);
+        await slack.sendWelcomeMessage(botToken, response.data.authed_user.id);
 
         // deep link to slack app or redirect to slack team in web.
         res.redirect(

--- a/server/routes/__test__/auth.test.js
+++ b/server/routes/__test__/auth.test.js
@@ -46,17 +46,20 @@ describe("GET /api/v1/auth/oauth - Complete slack app installation", () => {
     const update =  jest.fn(() => Promise.resolve());
     const team = { update , teamId, botAccessToken: botToken }
     const resp = {
-      url: "https://slack.com/api/oauth.access",
+      url: "https://slack.com/api/oauth.v2.access",
       statusCode: 200,
       data: {
-        access_token: "xoxp-XXXXXXXX-XXXXXXXX-XXXXX",
+        ok: true,
+        access_token: botToken,
+        token_type: "bot",
         scope: "incoming-webhook,commands,bot",
-        team_name: "mockTeam",
-        user_id: userId,
-        team_id: teamId,
-        bot: {
-          bot_user_id: "Bmock",
-          bot_access_token: botToken
+        bot_user_id: "Bmock",
+        team: {
+          id: teamId
+        },
+        authed_user: {
+          id: userId,
+          access_token: "xoxp-XXXXXXXX-XXXXXXXX-XXXXX"
         }
       }
     };


### PR DESCRIPTION
## Description

**Note:** Because of the merge freeze and all, I don't expect these changes to go through soon. I'm more putting this PR up for visibility and to make the project hand-off a little easier.

Migrating away from the legacy Slack app lets us resubmit to the Slack app directory and ensures our app stays listed past November 2021. More info about this here: https://api.slack.com/authentication/migration#faq_directory_schedule.

I followed the steps given [here](https://api.slack.com/authentication/migration) for migrating our Slack app:
- Changed our scopes to the new, granular scopes system
- Updated OAuth use Slack's new `v2` flow
  - Updated "Add to Slack" buttons on public-facing documentation to use new OAuth flow

## Next Steps

### Testing

I haven't fully tested the [subscriptions or link preview](https://datadotworld.github.io/slack-app/) features yet - it's possible I missed some scopes that enable this functionality. However, those features are hardcoded to only work for `data.world` links, while I was testing using `ddw` links, which made testing difficult on my local dev Slack app. Once we merge to master, we can deploy to the staging environment and test in an easy manner there.

Installing to a Slack workspace, associating with a data.world account, and generating per-channel webhooks has been tested locally.

### Resubmitting to the Slack app directory

After testing functionality in staging, we can resubmit to the Slack app directory ([instructions](https://api.slack.com/start/distributing/directory#resubmitting)). If we add new scopes to the Slack app, we either need to:
- Handle 2 sets of scopes, the legacy scopes and the new ones. This would involve adding error handling on API calls that require new scopes that were not included in the legacy bot. 
- Force users to reinstall the app by calling [auth.revoke](https://api.slack.com/methods/auth.revoke) on all user tokens. These can be found in the `Teams` table under the `access_token` and `bot_access_token` columns. More instructions about getting users to reinstall [here](https://api.slack.com/authentication/migration#cleanup).

I know @mariechatfield has experience performing a Slack app upgrade, so she might have some insight on this process.