### PR TITLE
[PAPPY-349] Node version update to support Heroku 22 version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/slack-app
     docker:
-      - image: circleci/node:12.0.0
+      - image: circleci/node:14.19.2
       - image: postgres:10.4
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/slack-app
     docker:
-      - image: circleci/node:14.19.2
+      - image: circleci/node:12.0.0
       - image: postgres:10.4
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/slack-app
     docker:
-      - image: circleci/node:8.9.4
+      - image: circleci/node:14.15.4
       - image: postgres:10.4
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/slack-app
     docker:
-      - image: circleci/node:14.15.4
+      - image: circleci/node:12.0.0
       - image: postgres:10.4
     steps:
       - checkout

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "14.15.4"
+    "node": "12.0.0"
   },
   "dependencies": {
     "@slack/client": "^3.16.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "12.0.0"
+    "node": "14.19.2"
   },
   "dependencies": {
     "@slack/client": "^3.16.0",
@@ -28,8 +28,8 @@
     "react-router": "4.2.0",
     "react-router-dom": "4.2.2",
     "react-scripts": "^1.1.5",
-    "sequelize": "^4.37.6",
-    "sequelize-cli": "^4.0.0",
+    "sequelize": "^6.21.1",
+    "sequelize-cli": "^6.4.1",
     "serve-favicon": "~2.4.5",
     "url": "^0.11.0",
     "uuid": "^3.2.1"
@@ -49,6 +49,7 @@
     "husky": "^0.14.3",
     "jest": "^23.3.0",
     "jest-junit": "^5.1.0",
+    "sequelize-cli": "^6.4.1",
     "supertest": "^3.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "16.18.0"
+    "node": "14.15.4"
   },
   "dependencies": {
     "@slack/client": "^3.16.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "slack-app",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "16.18.0"
+  },
   "dependencies": {
     "@slack/client": "^3.16.0",
     "@slack/web-api": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "14.19.2"
+    "node": "12.0.0"
   },
   "dependencies": {
     "@slack/client": "^3.16.0",
@@ -28,8 +28,8 @@
     "react-router": "4.2.0",
     "react-router-dom": "4.2.2",
     "react-scripts": "^1.1.5",
-    "sequelize": "^6.21.1",
-    "sequelize-cli": "^6.4.1",
+    "sequelize": "^4.37.6",
+    "sequelize-cli": "^4.0.0",
     "serve-favicon": "~2.4.5",
     "url": "^0.11.0",
     "uuid": "^3.2.1"
@@ -49,7 +49,6 @@
     "husky": "^0.14.3",
     "jest": "^23.3.0",
     "jest-junit": "^5.1.0",
-    "sequelize-cli": "^6.4.1",
     "supertest": "^3.1.0"
   }
 }


### PR DESCRIPTION
Ticket : https://dataworld.atlassian.net/browse/PAPPY-349

This PR to support Heroku upgrade. New Heroku doesn't support node` 8.9.4` version. So set to `12.0.0`. 
Created new slack app and tested this changes against app.

Note : Nikhil PR(https://github.com/datadotworld/slack-app/pull/78) have new  node version. This version `14.19.2` need update some module. It is already covered in the Nikhil PR. So I have not set 14.19.2 or higher version.