### PR TITLE
[ENG-3054]  Allow all users to view subscriptions

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -21,7 +21,7 @@
           <h2 class="lead" style="font-weight: light ">Get updates on subscribed data sources and provide insight into shared links</h2>
 
           <div style="padding-top:20px;">
-            <a href="https://slack.com/oauth/v2/authorize?client_id=1508375017543.1545264648997&scope=channels:read,chat:write,commands,groups:read,im:history,im:read,im:write,links:read,links:write&user_scope=links:read,links:write">
+            <a href="https://slack.com/oauth/v2/authorize?client_id=1508375017543.1545264648997&scope=channels:read,chat:write,commands,groups:read,im:history,im:read,im:write,links:read,links:write&user_scope=links:read">
               <img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcSet="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" />
             </a>
           </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,7 +21,7 @@
           <h2 class="lead" style="font-weight: light ">Get updates on subscribed data sources and provide insight into shared links</h2>
 
           <div style="padding-top:20px;">
-            <a href="https://slack.com/oauth/v2/authorize?client_id=1508375017543.1545264648997&scope=channels:read,chat:write,commands,groups:read,im:history,im:read,im:write,links:read,links:write&user_scope=links:read">
+            <a href="https://slack.com/oauth/v2/authorize?client_id=1508375017543.1545264648997&scope=channels:read,chat:write,commands,groups:read,im:history,im:read,im:write,links:read,links:write">
               <img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcSet="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" />
             </a>
           </div>

--- a/manifest.yml
+++ b/manifest.yml
@@ -24,7 +24,6 @@ oauth_config:
   scopes:
     user:
       - links:read
-      - links:write
     bot:
       - channels:read
       - chat:write

--- a/manifest.yml
+++ b/manifest.yml
@@ -22,8 +22,6 @@ oauth_config:
   redirect_urls:
     - https://major-cougar-adequately.ngrok-free.app/api/v1/auth/oauth
   scopes:
-    user:
-      - links:read
     bot:
       - channels:read
       - chat:write
@@ -39,7 +37,6 @@ settings:
     request_url: https://major-cougar-adequately.ngrok-free.app/api/v1/unfurl/action
     user_events:
       - app_uninstalled
-      - link_shared
       - tokens_revoked
     bot_events:
       - link_shared

--- a/server/controllers/command.js
+++ b/server/controllers/command.js
@@ -212,6 +212,7 @@ const unsubscribeFromDatasetOrProject = async (
   command,
   responseUrl
 ) => {
+  let token;
   try {
     const commandText = process.env.SLASH_COMMAND;
 
@@ -236,7 +237,7 @@ const unsubscribeFromDatasetOrProject = async (
         where: { slackId: channelSubscription.slackUserId }
       });
 
-      const token = user.dwAccessToken;
+      token = user.dwAccessToken;
 
       // will be true if user subscribed to this resource in one channel
       if (removeDWSubscription) {

--- a/server/helpers/__test__/helper.test.js
+++ b/server/helpers/__test__/helper.test.js
@@ -109,7 +109,7 @@ describe("Test helper methods", () => {
     const [
       hasSubscriptionInChannel,
       removeDWsubscription
-    ] = await helper.getSubscriptionStatus(resourceid, channelId, userId);
+    ] = await helper.getSubscriptionStatus(resourceid, channelId);
 
     expect(Subscription.findAll).toHaveBeenCalledTimes(1);
     expect(hasSubscriptionInChannel).toBeTruthy();
@@ -129,7 +129,7 @@ describe("Test helper methods", () => {
     const [
       hasSubscriptionInChannel,
       removeDWsubscription
-    ] = await helper.getSubscriptionStatus(resourceid, channelid, userId);
+    ] = await helper.getSubscriptionStatus(resourceid, channelid);
 
     expect(Subscription.findAll).toHaveBeenCalledTimes(1);
     expect(hasSubscriptionInChannel).toBeFalsy();

--- a/server/helpers/helper.js
+++ b/server/helpers/helper.js
@@ -109,12 +109,11 @@ const shouldRetry = (error) => {
   return error.response && error.response.status === 429;
 }
 
-const getSubscriptionStatus = async (resourceid, channelid, userId) => {
+const getSubscriptionStatus = async (resourceid, channelid) => {
   try {
     const subscriptions = await Subscription.findAll({
       where: {
-        resourceId: resourceid,
-        slackUserId: userId
+        resourceId: resourceid
       }
     });
     const channelSubscriptions = collection.filter(subscriptions, function(o) {


### PR DESCRIPTION
- Allow all slack users within a workspace to see and manage all DW resource subscriptions 
- Remove redundant user events
- Update test

Ticket : https://dataworld.atlassian.net/browse/ENG-3054