### PR TITLE
Refactored auth controller

### DIFF
--- a/server/controllers/__test__/auth.test.js
+++ b/server/controllers/__test__/auth.test.js
@@ -17,7 +17,7 @@
  * This product includes software developed at
  * data.world, Inc. (http://data.world/).
  */
-const auth = require("../auth");
+const auth = require("../../services/auth");
 const dataworld = require("../../api/dataworld");
 const slack = require("../../api/slack");
 const User = require("../../models").User;

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -17,214 +17,84 @@
  * This product includes software developed at
  * data.world, Inc. (http://data.world/).
  */
-const crypto = require('crypto');
-const qs = require('qs');
-
-const Subscription = require("../models").Subscription;
 const User = require("../models").User;
 const Team = require("../models").Team;
-
-const uuidv1 = require("uuid/v1");
-const Sequelize = require("sequelize");
 
 const dataworld = require("../api/dataworld");
 const slack = require("../api/slack");
 
-const Op = Sequelize.Op;
-
-const slackOauth = (req, res) => {
-  // When a user authorizes an app, a code query parameter is passed on the oAuth endpoint.
+const handleSlackAppInstallation = async (req, res) => {
+  // When a user authorizes an app, a code query parameter is passed to the oAuth endpoint.
   // If that code is not there, we respond with an error message
   const baseUrl = `${req.protocol}://${req.get("host")}`;
   if (!req.query.code) {
     return res.redirect(`${baseUrl}/failed`);
   }
-  // If it's there...
-  // call slack api
-  slack
-    .oauthAccess(req.query.code)
-    .then(async response => {
-      // create team with returned data
-      const [team, created] = await Team.findOrCreate({
-        where: { teamId: response.data.team.id },
-        defaults: {
-          teamDomain: response.data.team.name,
-          accessToken: response.data.authed_user.access_token,
-          botUserId: response.data.bot_user_id,
-          botAccessToken: response.data.access_token
-        }
-      });
-      try {
-        if (!created) {
-          // Team record already exits.
-          // Update existing record with new data
-          await team.update(
-            {
-              teamDomain: response.data.team.name,
-              accessToken: response.data.authed_user.access_token,
-              botUserId: response.data.bot_user_id,
-              botAccessToken: response.data.access_token
-            },
-            {
-              fields: [
-                "teamDomain",
-                "accessToken",
-                "botUserId",
-                "botAccessToken"
-              ]
-            }
-          );
-        }
-        //inform user via slack that installation was successful
-        const botToken = process.env.SLACK_BOT_TOKEN || team.botAccessToken;
-        await slack.sendWelcomeMessage(botToken, response.data.authed_user.id);
 
-        // deep link to slack app or redirect to slack team in web.
-        res.redirect(
-          `https://slack.com/app_redirect?app=${process.env.SLACK_APP_ID
-          }&team=${team.teamId}`
-        );
-      } catch (error) {
-        // error creating user
-        console.error(
-          "Failed complete new team creation process : " + error.message
-        );
-        // redirect to failure page
-        res.redirect(`${baseUrl}/failed`);
+  try {
+    var response = await slack.oauthAccess(req.query.code);
+
+    const [team, created] = await Team.findOrCreate({
+      where: { teamId: response.data.team.id },
+      defaults: {
+        teamDomain: response.data.team.name,
+        accessToken: response.data.authed_user.access_token,
+        botUserId: response.data.bot_user_id,
+        botAccessToken: response.data.access_token
       }
-    })
-    .catch(error => {
-      console.error("Slack oauth failed : ", error);
+    });
+
+    try {
+      if (!created) {
+        // Team record already exits.
+        // Update existing record with new data
+        await team.update(
+          {
+            teamDomain: response.data.team.name,
+            accessToken: response.data.authed_user.access_token,
+            botUserId: response.data.bot_user_id,
+            botAccessToken: response.data.access_token
+          },
+          {
+            fields: [
+              "teamDomain",
+              "accessToken",
+              "botUserId",
+              "botAccessToken"
+            ]
+          }
+        );
+      }
+
+      //inform user via slack that installation was successful
+      const botToken = process.env.SLACK_BOT_TOKEN || team.botAccessToken;
+      await slack.sendWelcomeMessage(botToken, response.data.authed_user.id);
+
+      // deep link to slack app or redirect to slack team in web.
+      return res.redirect(
+        `https://slack.com/app_redirect?app=${process.env.SLACK_APP_ID
+        }&team=${team.teamId}`
+      );
+
+    } catch (error) {
+      // error creating user
+      console.error(
+        "Failed complete new team creation process : " + error.message
+      );
       // redirect to failure page
-      res.redirect(`${baseUrl}/failed`);
-    });
-};
-
-const verifySlackRequest = async (headers, body) => {
-  const slackSigningSecret = process.env.SLACK_SIGNING_SECRET;
-  const slackTimestamp = headers["x-slack-request-timestamp"];
-  const slackSignature = headers["x-slack-signature"];
-
-  if (!(slackSigningSecret && slackTimestamp && slackSignature)) return false;
-
-  // It could be a replay attack, if the request timestamp is more than five minutes from local time.
-  const now = Math.floor(Date.now() / 1000);
-  if (now - parseInt(slackTimestamp, 10) > 60 * 5) return false;
-
-  // Validate the slack signature by comparing with computed signature
-  const signatureBaseString = "v0:" + slackTimestamp + ":" + body;
-  const mySignature = "v0=" + crypto.createHmac("sha256", slackSigningSecret).update(signatureBaseString, 'utf8').digest("hex");
-  return crypto.timingSafeEqual(Buffer.from(mySignature, 'utf8'), Buffer.from(slackSignature, 'utf8'));
-};
-
-const verifySlackClient = (req, res, next) => {
-  if (verifySlackRequest(req.headers, req.rawBody)) {
-    if (req.body.challenge) {
-      // Respond to slack challenge.
-      return res.status(200).send({ challenge: req.body.challenge });
+      return res.redirect(`${baseUrl}/failed`);
     }
-    if (req.body.ssl_check) {
-      return res.status(200).send();
-    }
-    next();
-  } else {
-    next(new Error("Could not verify the request originated from Slack."));
-  }
-};
-
-const checkSlackAssociationStatus = async slackId => {
-  try {
-    let user = await User.findOne({
-      where: { slackId: slackId, dwAccessToken: { [Op.ne]: null } }
-    });
-    let isAssociated = false;
-    if (user) {
-      // Check user association
-      // User found, now verify DW token is active/valid.
-      isAssociated = await dataworld.verifyDwToken(user.dwAccessToken);
-      if (!isAssociated) {
-        // Attempt to refresh token
-        const response = await dataworld.refreshToken(user.dwRefreshToken);
-        if (response) {
-          user = await user.update(
-            { dwAccessToken: response.data.access_token, dwRefreshToken: response.data.refresh_token },
-            { fields: ["dwAccessToken", "dwRefreshToken"] }
-          );
-          isAssociated = true;
-        } else {
-          // Access was revoked, this means all DW subscriptions for this user were removed
-          // We should do the same
-          await Subscription.destroy({
-            where: { slackUserId: slackId }
-          });
-        }
-      }
-    }
-    return [isAssociated, user];
   } catch (error) {
-    console.error("Error verifying slack association status : ", error.message);
-    throw error;
+    console.error("Slack oauth failed : ", error);
+    // redirect to failure page
+    return res.redirect(`${baseUrl}/failed`);
   }
 };
 
-const beginSlackAssociation = async (slackUserId, teamId, channelId) => {
-  try {
-    let nonce = uuidv1();
-    const team = await Team.findOne({ where: { teamId: teamId } });
-    const botToken = process.env.SLACK_BOT_TOKEN || team.botAccessToken;
-
-    // create user with nonce and the slackdata
-    const [user, created] = await User.findOrCreate({
-      where: { slackId: slackUserId },
-      defaults: { teamId: teamId, nonce: nonce }
-    });
-
-    // Inform user that authentication is required
-    await slack.sendAuthRequiredMessage(
-      botToken,
-      user.nonce,
-      channelId,
-      slackUserId
-    );
-  } catch (error) {
-    console.error("Begin slack association error : ", error.message);
-  }
-};
-
-// TODO: This can be merged with beginSlackAssociation and replaced across project.
-const beginUnfurlSlackAssociation = async (
-  userId,
-  channel,
-  teamId,
-  messageTs
-) => {
-  try {
-    const nonce = uuidv1();
-    const team = await Team.findOne({ where: { teamId: teamId } });
-    const botAccessToken = process.env.SLACK_BOT_TOKEN || team.botAccessToken;
-    const teamAccessToken = process.env.SLACK_TEAM_TOKEN || team.accessToken;
-    // create user with nonce and the slackdata
-    const [user, created] = await User.findOrCreate({
-      where: { slackId: userId },
-      defaults: { teamId: teamId, nonce: nonce }
-    });
-
-    await slack.startUnfurlAssociation(
-      user.nonce,
-      botAccessToken,
-      channel,
-      userId,
-      messageTs,
-      teamAccessToken
-    );
-  } catch (error) {
-    console.error("Begin unfurl slack association error : ", error);
-  }
-};
-
-const completeSlackAssociation = async (req, res) => {
+const completeDataworldAccountAssociation = async (req, res) => {
   try {
     const response = await dataworld.exchangeAuthCode(req.query.code);
+
     if (response.error) {
       return res.status(400).send("failed");
     } else {
@@ -267,11 +137,6 @@ const completeSlackAssociation = async (req, res) => {
 };
 
 module.exports = {
-  slackOauth,
-  verifySlackClient,
-  verifySlackRequest,
-  checkSlackAssociationStatus,
-  beginSlackAssociation,
-  beginUnfurlSlackAssociation,
-  completeSlackAssociation
+  handleSlackAppInstallation,
+  completeDataworldAccountAssociation
 };

--- a/server/controllers/command.js
+++ b/server/controllers/command.js
@@ -26,7 +26,7 @@ const array = require("lodash/array");
 const collection = require("lodash/collection");
 const lang = require("lodash/lang");
 
-const auth = require("./auth");
+const auth = require("../services/auth");
 const dataworld = require("../api/dataworld");
 const helper = require("../helpers/helper");
 const slack = require("../api/slack");

--- a/server/controllers/unfurl.js
+++ b/server/controllers/unfurl.js
@@ -28,7 +28,7 @@ const object = require("lodash/object");
 const pretty = require("prettysize");
 const moment = require("moment");
 
-const auth = require("./auth");
+const auth = require("../services/auth");
 const dataworld = require("../api/dataworld");
 const helper = require("../helpers/helper");
 const slack = require("../api/slack");

--- a/server/middlewares/auth.js
+++ b/server/middlewares/auth.js
@@ -1,0 +1,59 @@
+/*
+ * data.world Slack Application
+ * Copyright 2018 data.world, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This product includes software developed at
+ * data.world, Inc. (http://data.world/).
+ */
+
+const crypto = require('crypto');
+
+const verifySlackRequest = async (headers, body) => {
+    const slackSigningSecret = process.env.SLACK_SIGNING_SECRET;
+    const slackTimestamp = headers["x-slack-request-timestamp"];
+    const slackSignature = headers["x-slack-signature"];
+  
+    if (!(slackSigningSecret && slackTimestamp && slackSignature)) return false;
+  
+    // It could be a replay attack, if the request timestamp is more than five minutes from local time.
+    const now = Math.floor(Date.now() / 1000);
+    if (now - parseInt(slackTimestamp, 10) > 60 * 5) return false;
+  
+    // Validate the slack signature by comparing with computed signature
+    const signatureBaseString = "v0:" + slackTimestamp + ":" + body;
+    const mySignature = "v0=" + crypto.createHmac("sha256", slackSigningSecret).update(signatureBaseString, 'utf8').digest("hex");
+    return crypto.timingSafeEqual(Buffer.from(mySignature, 'utf8'), Buffer.from(slackSignature, 'utf8'));
+  };
+  
+const verifySlackClient = (req, res, next) => {
+    if (verifySlackRequest(req.headers, req.rawBody)) {
+      if (req.body.challenge) {
+        // Respond to slack challenge.
+        return res.status(200).send({ challenge: req.body.challenge });
+      }
+      if (req.body.ssl_check) {
+        return res.status(200).send();
+      }
+      next();
+    } else {
+      next(new Error("Could not verify the request originated from Slack."));
+    }
+  };
+
+
+module.exports = {
+    verifySlackClient,
+    verifySlackRequest
+};

--- a/server/routes/__test__/command.test.js
+++ b/server/routes/__test__/command.test.js
@@ -19,7 +19,8 @@
  */
 const request = require("supertest");
 const server = require("../../app");
-const auth = require("../../controllers/auth");
+const auth = require("../../services/auth");
+const authMiddleware = require("../../middlewares/auth");
 const dataworld = require("../../api/dataworld");
 const slack = require("../../api/slack");
 const helper = require("../../helpers/helper");
@@ -35,7 +36,7 @@ const dwDomain = helper.DW_DOMAIN;
 describe("POST /api/v1/command/ - Process slash command", () => {
   it("should respond to slack challenge request", done => {
     const challenge = "challenge";
-    auth.verifySlackRequest = jest.fn(() => true);
+    authMiddleware.verifySlackRequest = jest.fn(() => true);
     request(server)
       .post("/api/v1/command/")
       .send({ challenge })
@@ -49,7 +50,7 @@ describe("POST /api/v1/command/ - Process slash command", () => {
 
   it("should handle slack ssl check properly", done => {
     const ssl_check = "ssl_check";
-    auth.verifySlackRequest = jest.fn(() => true);
+    authMiddleware.verifySlackRequest = jest.fn(() => true);
     request(server)
       .post("/api/v1/command/")
       .send({ ssl_check })

--- a/server/routes/__test__/unfurl.test.js
+++ b/server/routes/__test__/unfurl.test.js
@@ -19,7 +19,7 @@
  */
 const request = require("supertest");
 const server = require("../../app");
-const auth = require("../../controllers/auth");
+const auth = require("../../services/auth");
 const dataworld = require("../../api/dataworld");
 const slack = require("../../api/slack");
 const Channel = require("../../models").Channel;

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -23,9 +23,9 @@ const auth = require("../controllers/auth");
 
 const router = express.Router();
 
-router.get("/exchange", auth.completeSlackAssociation);
+router.get("/exchange", auth.completeDataworldAccountAssociation);
 
 // endpoint for handling slack app installation
-router.get("/oauth", auth.slackOauth);
+router.get("/oauth", auth.handleSlackAppInstallation);
 
 module.exports = router;

--- a/server/routes/command.js
+++ b/server/routes/command.js
@@ -19,7 +19,7 @@
  */
 const express = require("express");
 
-const auth = require("../controllers/auth");
+const auth = require("../middlewares/auth");
 const command = require("../controllers/command");
 
 const router = express.Router();
@@ -27,6 +27,7 @@ const router = express.Router();
 /* Slack command. */
 router.post("/", auth.verifySlackClient, command.validateAndProcessCommand);
 
+// TODO : This should be moved to 
 /* Slack action button events. */
 router.post("/action", command.performAction);
 

--- a/server/routes/command.js
+++ b/server/routes/command.js
@@ -27,7 +27,6 @@ const router = express.Router();
 /* Slack command. */
 router.post("/", auth.verifySlackClient, command.validateAndProcessCommand);
 
-// TODO : This should be moved to 
 /* Slack action button events. */
 router.post("/action", command.performAction);
 

--- a/server/routes/unfurl.js
+++ b/server/routes/unfurl.js
@@ -24,7 +24,6 @@ const { unfurl } = require("../controllers/unfurl");
 
 const router = express.Router();
 
-// Deperecated : to be replaced by new /events endpoint
 /* Slack incomming webhook. */
 router.post("/action", auth.verifySlackClient, unfurl.processRequest);
 

--- a/server/services/auth.js
+++ b/server/services/auth.js
@@ -1,0 +1,126 @@
+/*
+ * data.world Slack Application
+ * Copyright 2018 data.world, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This product includes software developed at
+ * data.world, Inc. (http://data.world/).
+ */
+
+const Subscription = require("../models").Subscription;
+const User = require("../models").User;
+const Team = require("../models").Team;
+
+const uuidv1 = require("uuid/v1");
+const Sequelize = require("sequelize");
+
+const dataworld = require("../api/dataworld");
+const slack = require("../api/slack");
+
+const Op = Sequelize.Op;
+
+const checkSlackAssociationStatus = async slackId => {
+  try {
+    let user = await User.findOne({
+      where: { slackId: slackId, dwAccessToken: { [Op.ne]: null } }
+    });
+    let isAssociated = false;
+    if (user) {
+      // Check user association
+      // User found, now verify DW token is active/valid.
+      isAssociated = await dataworld.verifyDwToken(user.dwAccessToken);
+      if (!isAssociated) {
+        // Attempt to refresh token
+        const response = await dataworld.refreshToken(user.dwRefreshToken);
+        if (response) {
+          user = await user.update(
+            { dwAccessToken: response.data.access_token, dwRefreshToken: response.data.refresh_token },
+            { fields: ["dwAccessToken", "dwRefreshToken"] }
+          );
+          isAssociated = true;
+        } else {
+          // Access was revoked, this means all DW subscriptions for this user were removed
+          // We should do the same
+          await Subscription.destroy({
+            where: { slackUserId: slackId }
+          });
+        }
+      }
+    }
+    return [isAssociated, user];
+  } catch (error) {
+    console.error("Error verifying slack association status : ", error.message);
+    throw error;
+  }
+};
+
+const beginSlackAssociation = async (slackUserId, teamId, channelId) => {
+  try {
+    let nonce = uuidv1();
+    const team = await Team.findOne({ where: { teamId: teamId } });
+    const botToken = process.env.SLACK_BOT_TOKEN || team.botAccessToken;
+
+    // create user with nonce and the slackdata
+    const [user, created] = await User.findOrCreate({
+      where: { slackId: slackUserId },
+      defaults: { teamId: teamId, nonce: nonce }
+    });
+
+    // Inform user that authentication is required
+    await slack.sendAuthRequiredMessage(
+      botToken,
+      user.nonce,
+      channelId,
+      slackUserId
+    );
+  } catch (error) {
+    console.error("Begin slack association error : ", error.message);
+  }
+};
+
+const beginUnfurlSlackAssociation = async (
+  userId,
+  channel,
+  teamId,
+  messageTs
+) => {
+  try {
+    const nonce = uuidv1();
+    const team = await Team.findOne({ where: { teamId: teamId } });
+    const botAccessToken = process.env.SLACK_BOT_TOKEN || team.botAccessToken;
+    const teamAccessToken = process.env.SLACK_TEAM_TOKEN || team.accessToken;
+    // create user with nonce and the slackdata
+    const [user, created] = await User.findOrCreate({
+      where: { slackId: userId },
+      defaults: { teamId: teamId, nonce: nonce }
+    });
+
+    await slack.startUnfurlAssociation(
+      user.nonce,
+      botAccessToken,
+      channel,
+      userId,
+      messageTs,
+      teamAccessToken
+    );
+  } catch (error) {
+    console.error("Begin unfurl slack association error : ", error);
+  }
+};
+
+module.exports = {
+  checkSlackAssociationStatus,
+  beginSlackAssociation,
+  beginUnfurlSlackAssociation,
+};

--- a/server/services/blocks.js
+++ b/server/services/blocks.js
@@ -17,15 +17,5 @@
  * This product includes software developed at
  * data.world, Inc. (http://data.world/).
  */
-const express = require("express");
 
-const auth = require("../middlewares/auth");
-const { unfurl } = require("../controllers/unfurl");
-
-const router = express.Router();
-
-// Deperecated : to be replaced by new /events endpoint
-/* Slack incomming webhook. */
-router.post("/action", auth.verifySlackClient, unfurl.processRequest);
-
-module.exports = router;
+module.exports = { };

--- a/server/services/commands.js
+++ b/server/services/commands.js
@@ -17,15 +17,7 @@
  * This product includes software developed at
  * data.world, Inc. (http://data.world/).
  */
-const express = require("express");
 
-const auth = require("../middlewares/auth");
-const { unfurl } = require("../controllers/unfurl");
-
-const router = express.Router();
-
-// Deperecated : to be replaced by new /events endpoint
-/* Slack incomming webhook. */
-router.post("/action", auth.verifySlackClient, unfurl.processRequest);
-
-module.exports = router;
+// Visible for testing
+module.exports = {
+};

--- a/server/services/events.js
+++ b/server/services/events.js
@@ -17,15 +17,5 @@
  * This product includes software developed at
  * data.world, Inc. (http://data.world/).
  */
-const express = require("express");
 
-const auth = require("../middlewares/auth");
-const { unfurl } = require("../controllers/unfurl");
-
-const router = express.Router();
-
-// Deperecated : to be replaced by new /events endpoint
-/* Slack incomming webhook. */
-router.post("/action", auth.verifySlackClient, unfurl.processRequest);
-
-module.exports = router;
+module.exports = { };

--- a/server/services/webhooks.js
+++ b/server/services/webhooks.js
@@ -17,15 +17,5 @@
  * This product includes software developed at
  * data.world, Inc. (http://data.world/).
  */
-const express = require("express");
 
-const auth = require("../middlewares/auth");
-const { unfurl } = require("../controllers/unfurl");
-
-const router = express.Router();
-
-// Deperecated : to be replaced by new /events endpoint
-/* Slack incomming webhook. */
-router.post("/action", auth.verifySlackClient, unfurl.processRequest);
-
-module.exports = router;
+module.exports = { };


### PR DESCRIPTION
Atm, we have really large controllers that handles things that can be pushed into service layers (currently non-existent). This PR is the first in a series of PRs that would break current controllers into `controllers`, `services` and `middlewares` (where necessary). 

We're starting with the Auth controller, which has been broken down into an  `AuthController`, `AuthService` and `AuthMiddleware` .  There has not been any implementation changes, we're mostly moving things around and renaming methods for clarity.