### PR TITLE
Add term search command

### DIFF
--- a/server/api/__test__/slack.test.js
+++ b/server/api/__test__/slack.test.js
@@ -1,3 +1,4 @@
+const { text } = require("body-parser");
 const slack = require("../slack");
 const axios = require("axios");
 
@@ -28,14 +29,15 @@ describe("Test slack api wrapper.", () => {
   });
 
   it("should send response to slack", done => {
-    const data = {};
+    const message = "message"
+    const blocks = [{key: "value"}];
     const responseUrl = "responseUrl";
 
     axios.post = jest.fn(() => Promise.resolve());
 
-    slack.sendResponse(responseUrl, data);
+    slack.sendResponseMessageAndBlocks(responseUrl, message, blocks);
 
-    expect(axios.post).toHaveBeenCalledWith(responseUrl, data, { headers });
+    expect(axios.post).toHaveBeenCalledWith(responseUrl, {text: message, blocks, delete_original: false, replace_original: false }, { headers });
 
     done();
   });

--- a/server/api/dataworld.js
+++ b/server/api/dataworld.js
@@ -231,6 +231,20 @@ const acceptDatasetRequest = async (token, requestid, agentid, datasetid) => {
   return post(requestUrl, data, token);
 }
 
+// https://ddw-dwapipublic.dev.data.world/v0/search/resources?size=1
+
+const searchTerm = async (token, query, size) => {
+  const requestUrl = `${baseUrl}/search/resources?size=${size}`;
+  const data = {
+    "category": [
+      "catalogBusinessTerm"
+    ],
+    "includeCommunityResults": true,
+    query
+  }
+  return post(requestUrl, data, token);
+}
+
 const rejectDatasetRequest = async (token, requestid, agentid, datasetid) => {
   const requestUrl = `${baseUrl}/requests/reject`;
   const data = { requestid, owner: agentid, resourceid: datasetid };
@@ -265,6 +279,7 @@ module.exports = {
   unsubscribeFromAccount,
   acceptDatasetRequest,
   rejectDatasetRequest,
+  searchTerm,
   cancelDatasetRequest,
   verifyDwToken,
   refreshToken,

--- a/server/api/dataworld.js
+++ b/server/api/dataworld.js
@@ -231,10 +231,9 @@ const acceptDatasetRequest = async (token, requestid, agentid, datasetid) => {
   return post(requestUrl, data, token);
 }
 
-// https://ddw-dwapipublic.dev.data.world/v0/search/resources?size=1
-
-const searchTerm = async (token, query, size) => {
-  const requestUrl = `${baseUrl}/search/resources?size=${size}`;
+const searchTerm = async (token, query, size, nextPage) => {
+  const path = nextPage ? nextPage : `search/resources?size=${size}`;
+  const requestUrl = `${baseUrl}/${path}`;
   const data = {
     "category": [
       "catalogBusinessTerm"

--- a/server/api/slack.js
+++ b/server/api/slack.js
@@ -371,7 +371,6 @@ module.exports = {
   botBelongsToChannel,
   isDMChannel,
   oauthAccess,
-  sendResponse,
   sendWelcomeMessage,
   sendAuthRequiredMessage,
   startUnfurlAssociation,

--- a/server/controllers/__test__/command.test.js
+++ b/server/controllers/__test__/command.test.js
@@ -44,7 +44,7 @@ describe("Test Auth controller methods", () => {
       dataworld.subscribeToProject = jest.fn(() => Promise.resolve());
       dataworld.getDataset = jest.fn(() => Promise.resolve({ data: { isProject } }));
       dataworld.verifySubscriptionExists = jest.fn(() => Promise.resolve(false));
-      slack.sendResponse = jest.fn(() => Promise.resolve());
+      slack.sendResponseMessageAndBlocks = jest.fn(() => Promise.resolve());
 
       await commandService.handleDatasetorProjectSubscribeCommand(
         userid,
@@ -63,11 +63,7 @@ describe("Test Auth controller methods", () => {
         "datasetid",
         token
       );
-      expect(slack.sendResponse).toHaveBeenCalledWith(responseUrl, {
-        replace_original: false,
-        delete_original: false,
-        text: message
-      });
+      expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(responseUrl, message);
       done();
     },
     10000
@@ -85,7 +81,7 @@ describe("Test Auth controller methods", () => {
       const isProject = true;
 
       Subscription.findOne = jest.fn(() => Promise.resolve({}));
-      slack.sendResponse = jest.fn(() => Promise.resolve());
+      slack.sendResponseMessageAndBlocks = jest.fn(() => Promise.resolve());
       dataworld.getDataset = jest.fn(() => Promise.resolve({ data: { isProject } }));
       dataworld.verifySubscriptionExists = jest.fn(() => Promise.resolve(true));
 
@@ -100,11 +96,7 @@ describe("Test Auth controller methods", () => {
       expect(dataworld.getDataset).toHaveBeenCalledTimes(1);
       expect(dataworld.verifySubscriptionExists).toHaveBeenCalledTimes(1);
       expect(Subscription.findOne).toHaveBeenCalledTimes(1);
-      expect(slack.sendResponse).toHaveBeenCalledWith(responseUrl, {
-        replace_original: false,
-        delete_original: false,
-        text: message
-      });
+      expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(responseUrl, message);
       done();
     },
     10000
@@ -134,11 +126,8 @@ describe("Test Auth controller methods", () => {
 
     expect(dataworld.getDataset).toHaveBeenCalledTimes(1);
     expect(dataworld.verifySubscriptionExists).toHaveBeenCalledTimes(1);
-    expect(slack.sendResponse).toHaveBeenCalledWith(responseUrl, {
-      replace_original: false,
-      delete_original: false,
-      text: "Failed to subscribe to *datasetid*. Please make sure to subscribe using a valid dataset or project URL."
-    });
+    expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(responseUrl,
+       "Failed to subscribe to *datasetid*. Please make sure to subscribe using a valid dataset or project URL.");
 
     done();
   });
@@ -157,7 +146,7 @@ describe("Test Auth controller methods", () => {
     Subscription.findOrCreate = jest.fn(() => Promise.resolve([{}, true]));
     dataworld.subscribeToAccount = jest.fn(() => Promise.resolve({ data }));
     dataworld.verifySubscriptionExists = jest.fn(() => Promise.resolve(false));
-    slack.sendResponse = jest.fn(() => Promise.resolve());
+    slack.sendResponseMessageAndBlocks = jest.fn(() => Promise.resolve());
 
     await commandService.handleAccountSubscribeCommand(
       userid,
@@ -171,11 +160,7 @@ describe("Test Auth controller methods", () => {
     expect(Subscription.findOrCreate).toHaveBeenCalledTimes(1);
     expect(dataworld.verifySubscriptionExists).toHaveBeenCalledTimes(1);
     expect(dataworld.subscribeToAccount).toHaveBeenCalledWith("agentid", token);
-    expect(slack.sendResponse).toHaveBeenCalledWith(responseUrl, {
-      replace_original: false,
-      delete_original: false,
-      text: message
-    });
+    expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(responseUrl, message);
     done();
   });
 
@@ -189,7 +174,7 @@ describe("Test Auth controller methods", () => {
     const message = "Subscription already exists in this channel. No further action required!";
 
     Subscription.findOne = jest.fn(() => Promise.resolve({}));
-    slack.sendResponse = jest.fn(() => Promise.resolve());
+    slack.sendResponseMessageAndBlocks = jest.fn(() => Promise.resolve());
     dataworld.verifySubscriptionExists = jest.fn(() => Promise.resolve(true));
 
     await commandService.handleAccountSubscribeCommand(
@@ -202,11 +187,7 @@ describe("Test Auth controller methods", () => {
 
     expect(Subscription.findOne).toHaveBeenCalledTimes(1);
     expect(dataworld.verifySubscriptionExists).toHaveBeenCalledTimes(1);
-    expect(slack.sendResponse).toHaveBeenCalledWith(responseUrl, {
-      replace_original: false,
-      delete_original: false,
-      text: message
-    });
+    expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(responseUrl, message);
     done();
   });
 
@@ -220,7 +201,7 @@ describe("Test Auth controller methods", () => {
     Subscription.findOne = jest.fn(() =>
       Promise.reject(new Error("Test - Failed to get subscription form DB"))
     );
-    slack.sendResponse = jest.fn(() => Promise.resolve());
+    slack.sendResponseMessageAndBlocks = jest.fn(() => Promise.resolve());
     dataworld.verifySubscriptionExists = jest.fn(() => Promise.resolve(true));
 
     await commandService.handleAccountSubscribeCommand(
@@ -233,11 +214,8 @@ describe("Test Auth controller methods", () => {
 
     expect(Subscription.findOne).toHaveBeenCalledTimes(1);
     expect(dataworld.verifySubscriptionExists).toHaveBeenCalledTimes(1);
-    expect(slack.sendResponse).toHaveBeenCalledWith(responseUrl, {
-      replace_original: false,
-      delete_original: false,
-      text: "Failed to subscribe to *agentid*. Is that a valid data.world account ID?"
-    });
+    expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(responseUrl, 
+      "Failed to subscribe to *agentid*. Is that a valid data.world account ID?");
     done();
   });
 
@@ -247,7 +225,7 @@ describe("Test Auth controller methods", () => {
     const responseUrl = "responseUrl";
 
     helper.getSubscriptionStatus = jest.fn(() => [false, false]);
-    slack.sendResponse = jest.fn(() => Promise.resolve());
+    slack.sendResponseMessageAndBlocks = jest.fn(() => Promise.resolve());
 
     await commandService.handleDatasetOrProjectUnsubscribeCommand(
       channelid,
@@ -259,12 +237,8 @@ describe("Test Auth controller methods", () => {
       "owner/datasetid",
       channelid     
     );
-    expect(slack.sendResponse).toHaveBeenCalledWith(responseUrl, {
-      replace_original: false,
-      delete_original: false,
-      text:
-        `No subscription found for *owner/datasetid* here. Use \`/${process.env.SLASH_COMMAND} list\` to list all active subscriptions.`
-    });
+    expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(responseUrl, 
+      `No subscription found for *owner/datasetid* here. Use \`/${process.env.SLASH_COMMAND} list\` to list all active subscriptions.`);
     done();
   });
 
@@ -275,13 +249,7 @@ describe("Test Auth controller methods", () => {
       const cmd = "subscribe owner/datasetid";
       const responseUrl = "responseUrl";
       const error = new Error("Test - error");
-      const data = {
-        replace_original: false,
-        delete_original: false,
-        text: "Failed to unsubscribe from *datasetid*."
-      };
-
-      slack.sendResponse = jest.fn(() => Promise.resolve());
+      slack.sendResponseMessageAndBlocks = jest.fn(() => Promise.resolve());
       helper.getSubscriptionStatus = jest.fn(() => Promise.reject(error));
 
       await commandService.handleDatasetOrProjectUnsubscribeCommand(
@@ -295,7 +263,7 @@ describe("Test Auth controller methods", () => {
         channelid,
       );
 
-      expect(slack.sendResponse).toHaveBeenCalledWith(responseUrl, data);
+      expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(responseUrl, "Failed to unsubscribe from *datasetid*.");
 
       done();
     },
@@ -311,19 +279,10 @@ describe("Test Auth controller methods", () => {
       const responseUrl = "responseUrl";
       const token = "token";
       const message = "No problem! You'll no longer receive notifications about *datasetid* here.";
-      const data = { message };
-      const slackData = {
-        replace_original: false,
-        delete_original: false,
-        text: message
-      };
-
       Subscription.destroy = jest.fn(() => Promise.resolve());
       helper.getSubscriptionStatus = jest.fn(() => Promise.resolve([true, true]));
-      dataworld.unsubscribeFromProject = jest.fn(() =>
-        Promise.resolve({ data })
-      );
-      slack.sendResponse = jest.fn(() => Promise.resolve());
+      dataworld.unsubscribeFromProject = jest.fn(() =>Promise.resolve());
+      slack.sendResponseMessageAndBlocks = jest.fn(() => Promise.resolve());
 
       await subscriptionService.unsubscribeFromProject(
         channelId,
@@ -335,7 +294,7 @@ describe("Test Auth controller methods", () => {
       expect(helper.getSubscriptionStatus).toHaveBeenCalledTimes(1);
       expect(Subscription.destroy).toHaveBeenCalledTimes(1);
       expect(dataworld.unsubscribeFromProject).toHaveBeenCalledTimes(1);
-      expect(slack.sendResponse).toHaveBeenCalledWith(responseUrl, slackData);
+      expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(responseUrl, message);
       done();
     },
     10000
@@ -348,12 +307,6 @@ describe("Test Auth controller methods", () => {
       const responseUrl = "responseUrl";
       const channelid = "channelid";
       const message = "No problem! You'll no longer receive notifications about *agentid* here.";
-      const data = { message };
-      const slackData = {
-        replace_original: false,
-        delete_original: false,
-        text: message
-      };
       const user = { dwAccessToken: "dwAccessToken" };
       const subscription = {  slackUserId: "slackUserId" };
 
@@ -362,10 +315,8 @@ describe("Test Auth controller methods", () => {
       Subscription.destroy = jest.fn(() => Promise.resolve());
 
       helper.getSubscriptionStatus = jest.fn(() => [true, true]);
-      dataworld.unsubscribeFromAccount = jest.fn(() =>
-        Promise.resolve({ data })
-      );
-      slack.sendResponse = jest.fn(() => Promise.resolve());
+      dataworld.unsubscribeFromAccount = jest.fn(() => Promise.resolve());
+      slack.sendResponseMessageAndBlocks = jest.fn(() => Promise.resolve());
 
       await commandService.handleUnsubscribeFromAccount(
         channelid,
@@ -377,7 +328,7 @@ describe("Test Auth controller methods", () => {
       expect(Subscription.findOne).toHaveBeenCalledTimes(1);
       expect(Subscription.destroy).toHaveBeenCalledTimes(1);
       expect(dataworld.unsubscribeFromAccount).toHaveBeenCalledTimes(1);
-      expect(slack.sendResponse).toHaveBeenCalledWith(responseUrl, slackData);
+      expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(responseUrl, message);
       done();
     },
     10000
@@ -456,14 +407,7 @@ describe("Test Auth controller methods", () => {
     };
     const subscriptions = [subscription];
 
-    const data = {
-      text: message,
-      blocks: blocks,
-      replace_original: false,
-      delete_original: false
-    };
-
-    slack.sendResponse = jest.fn(() => Promise.resolve());
+    slack.sendResponseMessageAndBlocks = jest.fn(() => Promise.resolve());
     Subscription.findAll = jest.fn(() => subscriptions);
     User.findOne = jest.fn(() => Promise.resolve({ dwAccessToken }));
     dataworld.verifySubscriptionExists = jest.fn(() => Promise.resolve(true));
@@ -471,12 +415,14 @@ describe("Test Auth controller methods", () => {
     await commandService.handleListSubscriptionCommand(
       req.body.response_url,
       req.body.channel_id,
-      req.body.user_id
+      req.body.user_id,
+      false,
+      false
     );
 
     expect(Subscription.findAll).toHaveBeenCalledTimes(1);
     expect(dataworld.verifySubscriptionExists).toHaveBeenCalledTimes(1);
-    expect(slack.sendResponse).toHaveBeenCalledWith("response_url", data);
+    expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith("response_url", message, blocks, false, false);
 
     done();
   });
@@ -490,24 +436,20 @@ describe("Test Auth controller methods", () => {
     const req = { body };
     const commandText = process.env.SLASH_COMMAND;
     const message = `No subscription found. Use \`\/${commandText} help\` to learn how to subscribe.`;
-    const data = {
-      text: message,
-      replace_original: false,
-      delete_original: false
-    };
 
-    slack.sendResponse = jest.fn(() => Promise.resolve());
+    slack.sendResponseMessageAndBlocks = jest.fn(() => Promise.resolve());
     Subscription.findAll = jest.fn(() => []);
 
     await commandService.handleListSubscriptionCommand(
       req.body.response_url,
       req.body.channel_id,
       req.body.user_id,
+      false,
       false
     );
 
     expect(Subscription.findAll).toHaveBeenCalledTimes(1);
-    expect(slack.sendResponse).toHaveBeenCalledWith("response_url", data);
+    expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith("response_url", message, undefined, false, false);
 
     done();
   });
@@ -520,13 +462,8 @@ describe("Test Auth controller methods", () => {
     };
     const req = { body };
     const message = `Failed to get subscriptions.`;
-    const data = {
-      text: message,
-      replace_original: false,
-      delete_original: false
-    };
 
-    slack.sendResponse = jest.fn(() => Promise.resolve());
+    slack.sendResponseMessageAndBlocks = jest.fn(() => Promise.resolve());
     Subscription.findAll = jest.fn(() =>
       Promise.reject(new Error("Test error"))
     );
@@ -539,7 +476,7 @@ describe("Test Auth controller methods", () => {
     );
 
     expect(Subscription.findAll).toHaveBeenCalledTimes(1);
-    expect(slack.sendResponse).toHaveBeenCalledWith("response_url", data);
+    expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith("response_url", message);
 
     done();
   });
@@ -573,16 +510,9 @@ describe("Test Auth controller methods", () => {
       });
     });
 
-    const data = {
-      text: message,
-      blocks: blocks,
-      replace_original: false,
-      delete_original: false
-    };
-
     await commandService.showHelp(responseUrl);
 
-    expect(slack.sendResponse).toHaveBeenCalledWith("response_url", data);
+    expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith("response_url", message, blocks);
 
     done();
   });

--- a/server/controllers/commands/__test__/request.test.js
+++ b/server/controllers/commands/__test__/request.test.js
@@ -122,7 +122,7 @@ describe('Test request command methods', () => {
 
       await requestCommands.handleDatasetRequestAction(defaultArguments)
 
-      expect(slack.sendResponse).not.toHaveBeenCalled()
+      expect(slack.sendResponseMessageAndBlocks).not.toHaveBeenCalled()
       expect(slack.openView).toHaveBeenCalledTimes(1)
       expect(slack.openView).toHaveBeenCalledWith(
         botToken,
@@ -143,7 +143,7 @@ describe('Test request command methods', () => {
 
       await requestCommands.handleDatasetRequestAction(defaultArguments)
 
-      expect(slack.sendResponse).not.toHaveBeenCalled()
+      expect(slack.sendResponseMessageAndBlocks).not.toHaveBeenCalled()
       expect(slack.openView).toHaveBeenCalledTimes(1)
       expect(slack.openView).toHaveBeenCalledWith(
         botToken,

--- a/server/controllers/commands/__test__/request.test.js
+++ b/server/controllers/commands/__test__/request.test.js
@@ -16,7 +16,7 @@ afterEach(() => {
 describe('Test request command methods', () => {
   describe('handleDatasetRequestAction', async () => {
     let defaultArguments
-    const botAccessToken = 'botAccessToken'
+    const botToken = 'botAccessToken'
     const dwAccessToken = 'dwAccessToken'
     const blockid = 'blockid'
     const channelid = 'channelid'
@@ -55,13 +55,15 @@ describe('Test request command methods', () => {
         agentid,
         datasetid
       )
-      expect(slack.sendResponse).toHaveBeenCalledTimes(1)
-      expect(slack.sendResponse).toHaveBeenCalledWith(
+      expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledTimes(1)
+      expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(
         responseUrl,
-        expect.objectContaining({ replace_original: true })
+        "",
+        expect.anything(),
+        true
       )
       // check that updated message is formatted correctly
-      expect(slack.sendResponse.mock.calls[0][1].blocks).toMatchSnapshot()
+      expect(slack.sendResponseMessageAndBlocks.mock.calls[0][2]).toMatchSnapshot()
     })
 
     it('should reject a dataset request and update the message', async () => {
@@ -76,13 +78,15 @@ describe('Test request command methods', () => {
         agentid,
         datasetid
       )
-      expect(slack.sendResponse).toHaveBeenCalledTimes(1)
-      expect(slack.sendResponse).toHaveBeenCalledWith(
+      expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledTimes(1)
+      expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(
         responseUrl,
-        expect.objectContaining({ replace_original: true })
+        "",
+        expect.anything(),
+        true
       )
       // check that updated message is formatted correctly
-      expect(slack.sendResponse.mock.calls[0][1].blocks).toMatchSnapshot()
+      expect(slack.sendResponseMessageAndBlocks.mock.calls[0][2]).toMatchSnapshot()
     })
 
     it('should cancel a dataset request and update the message', async () => {
@@ -97,13 +101,15 @@ describe('Test request command methods', () => {
         agentid,
         datasetid
       )
-      expect(slack.sendResponse).toHaveBeenCalledTimes(1)
-      expect(slack.sendResponse).toHaveBeenCalledWith(
+      expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledTimes(1)
+      expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(
         responseUrl,
-        expect.objectContaining({ replace_original: true })
+        "",
+        expect.anything(),
+        true
       )
       // check that updated message is formatted correctly
-      expect(slack.sendResponse.mock.calls[0][1].blocks).toMatchSnapshot()
+      expect(slack.sendResponseMessageAndBlocks.mock.calls[0][2]).toMatchSnapshot()
     })
 
     it('should handle unauthorized users', async () => {
@@ -111,7 +117,7 @@ describe('Test request command methods', () => {
         Promise.reject({ response: { status: 403 }})
       )
       tokensHelpers.getBotAccessTokenForChannel.mockImplementation(() =>
-        Promise.resolve(botAccessToken)
+        Promise.resolve({ botToken })
       )
 
       await requestCommands.handleDatasetRequestAction(defaultArguments)
@@ -119,7 +125,7 @@ describe('Test request command methods', () => {
       expect(slack.sendResponse).not.toHaveBeenCalled()
       expect(slack.openView).toHaveBeenCalledTimes(1)
       expect(slack.openView).toHaveBeenCalledWith(
-        botAccessToken,
+        botToken,
         triggerid,
         expect.anything()
       )
@@ -132,7 +138,7 @@ describe('Test request command methods', () => {
         Promise.reject({ response: { status: 400 }})
       )
       tokensHelpers.getBotAccessTokenForChannel.mockImplementation(() =>
-        Promise.resolve(botAccessToken)
+        Promise.resolve({botToken})
       )
 
       await requestCommands.handleDatasetRequestAction(defaultArguments)
@@ -140,7 +146,7 @@ describe('Test request command methods', () => {
       expect(slack.sendResponse).not.toHaveBeenCalled()
       expect(slack.openView).toHaveBeenCalledTimes(1)
       expect(slack.openView).toHaveBeenCalledWith(
-        botAccessToken,
+        botToken,
         triggerid,
         expect.anything()
       )

--- a/server/controllers/commands/__test__/webhook.test.js
+++ b/server/controllers/commands/__test__/webhook.test.js
@@ -29,9 +29,9 @@ describe('Test webhook command methods', () => {
         mockResponseUrl
       )
 
-      expect(slack.sendResponse).toHaveBeenCalledWith(
+      expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(
         mockResponseUrl,
-        { text: expect.stringContaining(mockWebhookUrl) }
+        expect.stringContaining(mockWebhookUrl)
       )
     })
 
@@ -48,9 +48,9 @@ describe('Test webhook command methods', () => {
           mockResponseUrl
         )
 
-        expect(slack.sendResponse).toHaveBeenCalledWith(
+        expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(
           mockResponseUrl,
-          { text: expect.stringContaining(existingWebhookId) }
+          expect.stringContaining(existingWebhookId)
         )
       })
     })
@@ -71,9 +71,9 @@ describe('Test webhook command methods', () => {
         )
 
         expect(Channel.update).toHaveBeenCalled()
-        expect(slack.sendResponse).toHaveBeenCalledWith(
+        expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(
           mockResponseUrl,
-          { text: expect.stringContaining(newWebhookId) }
+          expect.stringContaining(newWebhookId)
         )
       })
     })

--- a/server/controllers/commands/request.js
+++ b/server/controllers/commands/request.js
@@ -5,7 +5,7 @@ const { AUTHORIZATION_ACTIONS } = require('../../helpers/requests')
 const { getBotAccessTokenForChannel } = require('../../helpers/tokens')
 
 const openNotificationModal = async (channelId, triggerId, message) => {
-  const token = await getBotAccessTokenForChannel(channelId)
+  const {botToken} = await getBotAccessTokenForChannel(channelId)
   const modalView = {
     type: 'modal',
     title: {
@@ -22,7 +22,7 @@ const openNotificationModal = async (channelId, triggerId, message) => {
       }
     ]
   }
-  slack.openView(token, triggerId, modalView)
+  slack.openView(botToken, triggerId, modalView)
 }
 
 const updateMessageBlocksWithAction = (messageBlocks, blockId, userId, action) => {
@@ -92,10 +92,7 @@ const handleDatasetRequestAction = async ({
     userid,
     action
   )
-  slack.sendResponse(responseUrl, {
-    replace_original: true,
-    blocks: updatedBlocks
-  })
+  slack.sendResponseMessageAndBlocks(responseUrl, '', updatedBlocks, true)
 }
 
 module.exports = {

--- a/server/controllers/commands/webhook.js
+++ b/server/controllers/commands/webhook.js
@@ -19,11 +19,9 @@ const getOrCreateWebhookForChannel = async (channelId, responseUrl) => {
     )
   }
 
-  slack.sendResponse(responseUrl, {
-    text: `The webhook URL for this channel is \`${
-      webhookHelper.buildWebhookUrl(webhookId)
-    }\``
-  })
+  slack.sendResponseMessageAndBlocks(responseUrl, `The webhook URL for this channel is \`${
+    webhookHelper.buildWebhookUrl(webhookId)
+  }\``);
 }
 
 module.exports = {

--- a/server/controllers/events/requests.js
+++ b/server/controllers/events/requests.js
@@ -9,8 +9,8 @@ const { getBotAccessTokenForChannel } = require('../../helpers/tokens')
 
 const sendRequestEventToSlack = async (channelIds, blocks) => {
   await Promise.all(channelIds.map(async (channelId) => {
-    const token = await getBotAccessTokenForChannel(channelId)
-    await slack.sendMessageWithBlocks(token, channelId, blocks)
+    const { botToken } = await getBotAccessTokenForChannel(channelId);
+    await slack.postMessageWithBlocks(botToken, channelId, blocks)
   }))
 }
 

--- a/server/controllers/webhook.js
+++ b/server/controllers/webhook.js
@@ -767,10 +767,9 @@ const sendEventToSlack = async (channelIds, blocks) => {
   });
 };
 
-
 const sendSlackMessage = async (channelId, blocks, teamId) => {
-  const token = await getBotAccessTokenForTeam(teamId)
-  slack.sendMessageWithBlocks(token, channelId, blocks);
+  const {botToken} = await getBotAccessTokenForTeam(teamId)
+  slack.postMessageWithBlocks(botToken, channelId, blocks);
 };
 
 const webhook = {

--- a/server/helpers/helper.js
+++ b/server/helpers/helper.js
@@ -27,6 +27,11 @@ const DW_AUTH_URL = `${process.env.DW_AUTH_BASE_URL}?client_id=${
 }&response_type=code&redirect_uri=${process.env.DW_REDIRECT_URI}&state=`;
 const DW_DOMAIN = process.env.DW_DOMAIN || "data.world";
 
+const extractSearchTermFromCommand = (command) => {
+  const parts = command.split(" ");
+  return parts[parts.length - 1];
+};
+
 const extractParamsFromCommand = (command, isAccountCommand) => {
   const params = {};
   const parts = command.split(" ");
@@ -148,6 +153,7 @@ module.exports = {
   extractInsightsParams,
   extractIdFromLink,
   extractQueryParams,
+  extractSearchTermFromCommand,
   cleanSlackLinkInput,
   getSubscriptionStatus,
   getDelay,

--- a/server/helpers/helper.js
+++ b/server/helpers/helper.js
@@ -142,6 +142,16 @@ const getServerBaseUrl = (req) => {
   });
 }
 
+const trimStringToMaxLength = (str, maxLength = 3000) => {
+  // Check if the string length exceeds the maximum length
+  if (str.length > maxLength) {
+    // Trim the string to the maximum length
+    return str.substring(0, maxLength);
+  }
+  // If the string is within the maximum length, return it as is
+  return str;
+}
+
 module.exports = {
   FILES_LIMIT,
   LINKED_DATASET_LIMIT,
@@ -158,5 +168,6 @@ module.exports = {
   getSubscriptionStatus,
   getDelay,
   shouldRetry,
-  getServerBaseUrl
+  getServerBaseUrl,
+  trimStringToMaxLength
 };

--- a/server/helpers/tokens.js
+++ b/server/helpers/tokens.js
@@ -8,8 +8,13 @@ const getBotAccessTokenForChannel = async (channelId) => {
 
 const getBotAccessTokenForTeam = async (teamId) => {
   const team = await Team.findOne({ where: { teamId: teamId } })
-  const token = process.env.SLACK_BOT_TOKEN || team.botAccessToken
-  return token
+  const botToken = process.env.SLACK_BOT_TOKEN || team.botAccessToken
+  const teamAccessToken = process.env.SLACK_TEAM_TOKEN || team.teamAccessToken
+
+  return {
+    botToken,
+    teamAccessToken
+  }
 }
 
 module.exports = {

--- a/server/routes/__test__/auth.test.js
+++ b/server/routes/__test__/auth.test.js
@@ -78,7 +78,7 @@ describe("GET /api/v1/auth/oauth - Complete slack app installation", () => {
         expect(res.header.location).toEqual(
           `https://slack.com/app_redirect?app=${
             process.env.SLACK_APP_ID
-          }&team=${teamId}`
+          }&team=${teamId}&tab=messages`
         );
         expect(slack.oauthAccess).toHaveBeenCalledWith(code);
         expect(slack.sendWelcomeMessage).toHaveBeenCalledTimes(1);

--- a/server/routes/__test__/command.test.js
+++ b/server/routes/__test__/command.test.js
@@ -256,7 +256,7 @@ describe("POST /api/v1/command/action - Process an action", () => {
     helper.getSubscriptionStatus = jest.fn(() => Promise.resolve([true, true]));
     dataworld.unsubscribeFromDataset = jest.fn(() => Promise.resolve(response));
     slack.botBelongsToChannel = jest.fn(() => Promise.resolve(true));
-    slack.sendResponse = jest.fn(() => Promise.resolve());
+    slack.sendResponseMessageAndBlocks = jest.fn(() => Promise.resolve());
 
     request(server)
       .post("/api/v1/command/action")
@@ -268,7 +268,7 @@ describe("POST /api/v1/command/action - Process an action", () => {
           payloadObject.channel.id,
           botAccessToken
         );
-        expect(Team.findOne).toHaveBeenCalledTimes(2);
+        expect(Team.findOne).toHaveBeenCalledTimes(1);
         expect(Channel.findOrCreate).toHaveBeenCalledTimes(1);
         expect(User.findOne).toHaveBeenCalledTimes(1);
         expect(Subscription.findOne).toHaveBeenCalledTimes(1);
@@ -286,11 +286,7 @@ describe("POST /api/v1/command/action - Process an action", () => {
           parts.shift(),
           dwAccessToken
         );
-        expect(slack.sendResponse).toHaveBeenCalledWith(payloadObject.response_url, {
-          replace_original: false,
-          delete_original: false,
-          text: message
-        });
+        expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(payloadObject.response_url, message);
         done();
       });
   });
@@ -333,7 +329,7 @@ describe("POST /api/v1/command/action - Process an action", () => {
     dataworld.subscribeToProject = jest.fn(() => Promise.resolve(response));
     dataworld.verifySubscriptionExists = jest.fn(() => Promise.resolve(false));
     slack.botBelongsToChannel = jest.fn(() => Promise.resolve(true));
-    slack.sendResponse = jest.fn(() => Promise.resolve());
+    slack.sendResponseMessageAndBlocks = jest.fn(() => Promise.resolve());
 
     request(server)
       .post("/api/v1/command/action")
@@ -341,7 +337,7 @@ describe("POST /api/v1/command/action - Process an action", () => {
       .expect(200)
       .end((err, res) => {
         if (err) return done(err);
-        expect(Team.findOne).toHaveBeenCalledTimes(2);
+        expect(Team.findOne).toHaveBeenCalledTimes(1);
         expect(Channel.findOrCreate).toHaveBeenCalledTimes(1);
         expect(slack.botBelongsToChannel).toHaveBeenCalledWith(
           payloadObject.channel.id,
@@ -359,13 +355,9 @@ describe("POST /api/v1/command/action - Process an action", () => {
           id,
           dwAccessToken
         );
-        expect(slack.sendResponse).toHaveBeenCalledWith(
+        expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(
           payloadObject.response_url,
-          {
-            delete_original: false,
-            replace_original: false,
-            text: message
-          }
+          message
         );
         done();
       });
@@ -395,7 +387,7 @@ describe("POST /api/v1/command/action - Process an action", () => {
       );
       slack.botBelongsToChannel = jest.fn(() => Promise.resolve(true));
       slack.openView = jest.fn(() => Promise.resolve({}));
-      slack.sendResponse = jest.fn(() => Promise.resolve({}));
+      slack.sendResponseMessageAndBlocks = jest.fn(() => Promise.resolve({}));
     })
 
     it('should handle a successful action', async done => {
@@ -423,12 +415,11 @@ describe("POST /api/v1/command/action - Process an action", () => {
             agentid,
             datasetid
           );
-          expect(slack.sendResponse).toHaveBeenCalledWith(
+          expect(slack.sendResponseMessageAndBlocks).toHaveBeenCalledWith(
             datasetRequestActionPayload.response_url,
-            {
-              replace_original: true,
-              blocks: updatedBlocks
-            }
+            "",
+            updatedBlocks,
+            true
           );
           expect(slack.openView).not.toHaveBeenCalled();
           done();
@@ -469,7 +460,7 @@ describe("POST /api/v1/command/action - Process an action", () => {
             agentid,
             datasetid
           );
-          expect(slack.sendResponse).not.toHaveBeenCalled();
+          expect(slack.sendResponseMessageAndBlocks).not.toHaveBeenCalled();
           expect(slack.openView).toHaveBeenCalledWith(
             botAccessToken,
             datasetRequestActionPayload.trigger_id,

--- a/server/routes/__test__/unfurl.test.js
+++ b/server/routes/__test__/unfurl.test.js
@@ -24,8 +24,16 @@ const dataworld = require("../../api/dataworld");
 const slack = require("../../api/slack");
 const Channel = require("../../models").Channel;
 const Team = require("../../models").Team;
+const tokenHelpers = require("../../helpers/tokens");
 const Subscription = require("../../models").Subscription;
 const dwDomain = require("../../helpers/helper").DW_DOMAIN;
+
+jest.mock("../../helpers/tokens");
+
+beforeAll(() => {
+  tokenHelpers.getBotAccessTokenForTeam.mockImplementation(() => Promise.resolve({ botToken: "botAccessToken", teamAccessToken: "accessToken" }));
+  tokenHelpers.getBotAccessTokenForChannel.mockImplementation(() => Promise.resolve({ botToken: "botAccessToken" }));
+});
 
 describe("POST /api/v1/unfurl/action - Process unfurl requests", () => {
   const linkSharedEvent = {
@@ -178,7 +186,7 @@ describe("POST /api/v1/unfurl/action - Process unfurl requests", () => {
     const dwAccessToken = "dwAccessToken";
     const user = { dwAccessToken };
     const accessToken = process.env.SLACK_BOT_TOKEN || "accessToken";
-    const team = { teamId: "teamId", botAccessToken: "accessToken", accessToken };
+    const team = { teamId: "teamId", botAccessToken: "botAccessToken", accessToken };
     const ts = 1522193271;
     const dwAgentId = "kehesjay";
     const dwResourceId = "actors-proj";
@@ -265,7 +273,7 @@ describe("POST /api/v1/unfurl/action - Process unfurl requests", () => {
     agent.expect(200).end((err, res) => {
       if (err) return done(err);
       expect(auth.checkSlackAssociationStatus).toHaveBeenCalledWith(event.user);
-      expect(Team.findOne).toHaveBeenCalledTimes(2);
+      expect(tokenHelpers.getBotAccessTokenForTeam).toHaveBeenCalledWith("teamId");
       expect(dataworld.getDataset).toHaveBeenCalledWith(
         dwResourceId,
         dwAgentId,
@@ -296,7 +304,7 @@ describe("POST /api/v1/unfurl/action - Process unfurl requests", () => {
     const dwAccessToken = "dwAccessToken";
     const user = { dwAccessToken };
     const accessToken = process.env.SLACK_BOT_TOKEN || "accessToken";
-    const team = { teamId: "teamId", botAccessToken: "accessToken", accessToken };
+    const team = { teamId: "teamId", botAccessToken: "botAccessToken", accessToken };
     const ts = 1486421719;
     const dwAgentId = "kehesjay";
     const dwResourceId = "actors-proj";
@@ -380,7 +388,7 @@ describe("POST /api/v1/unfurl/action - Process unfurl requests", () => {
     agent.expect(200).end((err, res) => {
       if (err) return done(err);
       expect(auth.checkSlackAssociationStatus).toHaveBeenCalledWith(event.user);
-      expect(Team.findOne).toHaveBeenCalledTimes(2);
+      expect(tokenHelpers.getBotAccessTokenForTeam).toHaveBeenCalledWith("teamId");
       expect(dataworld.getDataset).toHaveBeenCalledWith(
         dwResourceId,
         dwAgentId,

--- a/server/routes/__test__/webhook.test.js
+++ b/server/routes/__test__/webhook.test.js
@@ -33,12 +33,8 @@ jest.mock("../../api/slack");
 jest.mock("../../helpers/tokens");
 
 beforeAll(() => {
-  tokenHelpers.getBotAccessTokenForTeam.mockImplementation(() =>
-    "botAccessToken"
-  );
-  tokenHelpers.getBotAccessTokenForChannel.mockImplementation(() =>
-    "botAccessToken"
-  );
+  tokenHelpers.getBotAccessTokenForTeam.mockImplementation(() => Promise.resolve({ botToken: "botAccessToken" }));
+  tokenHelpers.getBotAccessTokenForChannel.mockImplementation(() => Promise.resolve({ botToken: "botAccessToken" }));
 })
 
 describe("POST /api/v1/webhook/dw/events - Process DW webhook events", () => {
@@ -331,7 +327,7 @@ describe("POST /api/v1/webhook/dw/events - Process DW webhook events", () => {
     dataworld.getDataset = jest.fn(() => Promise.resolve({ data }));
     dataworld.getDWUser = jest.fn(() => Promise.resolve(ownerResponse));
 
-    slack.sendMessageWithBlocks = jest.fn();
+    slack.postMessageWithBlocks = jest.fn();
 
     agent.expect(200).end((err, res) => {
       if (err) return done(err);
@@ -344,7 +340,7 @@ describe("POST /api/v1/webhook/dw/events - Process DW webhook events", () => {
       );
       expect(dataworld.getDWUser).toHaveBeenCalledWith(dwAccessToken, dwAgentId);
       expect(Channel.findOne).toHaveBeenCalledTimes(1);
-      expect(slack.sendMessageWithBlocks).toHaveBeenCalledWith(
+      expect(slack.postMessageWithBlocks).toHaveBeenCalledWith(
         botAccessToken,
         channelId,
         expectedBlocks
@@ -435,12 +431,12 @@ describe("POST /api/v1/webhook/:webhookId", () => {
       .end((err, res) => {
         if (err) return done(err);
         done();
-        expect(slack.sendMessageWithBlocks).toHaveBeenCalledWith(
+        expect(slack.postMessageWithBlocks).toHaveBeenCalledWith(
           "botAccessToken",
           mockChannelId,
           expect.anything()
         );
-        expect(slack.sendMessageWithBlocks.mock.calls).toMatchSnapshot();
+        expect(slack.postMessageWithBlocks.mock.calls).toMatchSnapshot();
       });
   });
 
@@ -455,12 +451,12 @@ describe("POST /api/v1/webhook/:webhookId", () => {
       .end((err, res) => {
         if (err) return done(err);
         done();
-        expect(slack.sendMessageWithBlocks).toHaveBeenCalledWith(
+        expect(slack.postMessageWithBlocks).toHaveBeenCalledWith(
           "botAccessToken",
           mockChannelId,
           expect.anything()
         );
-        expect(slack.sendMessageWithBlocks.mock.calls).toMatchSnapshot();
+        expect(slack.postMessageWithBlocks.mock.calls).toMatchSnapshot();
       });
   });
 
@@ -498,7 +494,7 @@ describe("POST /api/v1/webhook/:webhookId", () => {
         if (err) return done(err);
         done();
         for (let i = 1; i <= 3; i++) {
-          expect(slack.sendMessageWithBlocks).toHaveBeenNthCalledWith(
+          expect(slack.postMessageWithBlocks).toHaveBeenNthCalledWith(
             i,
             "botAccessToken",
             `mockChannel${i}`,

--- a/server/services/actions.js
+++ b/server/services/actions.js
@@ -101,7 +101,7 @@ const handleButtonAction = async (payload, action, user) => {
     })
   } else {
     // unknow action
-    console.warn('Unknown action_id in button action event.')
+    console.warn(`Unknown action_id in button action event ${action.action_id}.`)
     return
   }
 }

--- a/server/services/actions.js
+++ b/server/services/actions.js
@@ -17,92 +17,17 @@
  * This product includes software developed at
  * data.world, Inc. (http://data.world/).
  */
-const array = require('lodash/array')
-const lang = require('lodash/lang')
-
-const slack = require('../api/slack')
-const { handleDatasetRequestAction } = require('../controllers/commands/request')
-const { AUTHORIZATION_ACTIONS } = require('../helpers/requests')
+const { getHandler } = require('../services/actions/action-provider')
 
 const commandService = require('../services/commands')
 
-const sendSlackBlock = (responseUrl, block) => {
-  try {
-    //data.blocks = attachment;
-    slack.sendResponse(responseUrl, { blocks: block }).catch(console.error)
-  } catch (error) {
-    console.error('Failed to send attachment to slack', error.message)
-  }
-}
-
-const sendSlackBlocks = async (
-  responseUrl,
-  message,
-  blocks,
-  replaceOriginal,
-  deleteOriginal,
-) => {
-  let data = { text: message }
-  if (blocks && !lang.isEmpty(blocks)) {
-    data.blocks = blocks
-  }
-  data.replace_original = replaceOriginal ? replaceOriginal : false
-  data.delete_original = deleteOriginal ? deleteOriginal : false
-  try {
-    await slack.sendResponse(responseUrl, data)
-  } catch (error) {
-    console.error('Failed to send message to slack', error.message)
-  }
-}
-
 const handleButtonAction = async (payload, action, user) => {
-  if (action.action_id === 'dataset_subscribe_button') {
-    await commandService.handleDatasetorProjectSubscribeCommand(
-      payload.user.id,
-      payload.channel.id,
-      `subscribe ${action.value}`,
-      payload.response_url,
-      user.dwAccessToken,
-    )
-
-    if (payload.container.is_app_unfurl) {
-      array.remove(
-        payload.app_unfurl.blocks.find((t) => t.type === 'actions').elements,
-        (element) => {
-          return element.action_id === 'dataset_subscribe_button'
-        },
-      )
-      // update unfurl attachment
-      sendSlackBlock(payload.response_url, payload.app_unfurl.blocks)
-    } else {
-      // update message attachments
-      array.remove(
-        payload.message.blocks.find((t) => t.type === 'actions').elements,
-        (element) => {
-          return element.action_id === 'dataset_subscribe_button'
-        },
-      )
-      sendSlackBlocks(payload.response_url, '', payload.message.blocks, true)
-    }
-  } else if (Object.values(AUTHORIZATION_ACTIONS).includes(action.action_id)) {
-    const { requestid, agentid, datasetid } = JSON.parse(action.value)
-    await handleDatasetRequestAction({
-      channelid: payload.channel.id,
-      userid: payload.user.id,
-      triggerid: payload.trigger_id,
-      responseUrl: payload.response_url,
-      message: payload.message,
-      blockid: action.block_id,
-      actionid: action.action_id,
-      requestid,
-      agentid,
-      datasetid,
-      dwAccessToken: user.dwAccessToken,
-    })
+  const actionHandler = getHandler(action.action_id);
+  if (actionHandler) {
+    await actionHandler.handle(payload, action, user);
   } else {
     // unknow action
-    console.warn(`Unknown action_id in button action event ${action.action_id}.`)
-    return
+    console.warn(`Unknown action_id in button action event ${action.action_id}`);
   }
 }
 
@@ -141,8 +66,6 @@ const handleMenuAction = async (payload, action) => {
 
 // Visible for testing
 module.exports = {
-  sendSlackBlock,
-  sendSlackBlocks,
   handleButtonAction,
   handleMenuAction,
 }

--- a/server/services/actions/action-provider.js
+++ b/server/services/actions/action-provider.js
@@ -17,15 +17,26 @@
  * This product includes software developed at
  * data.world, Inc. (http://data.world/).
  */
+const authorizationRequestActionButtonsHandler = require('./handlers/authorization_request_action_buttons');
+const clearSearchResultsButton = require('./handlers/search/clear_search_results_button');
 const datasetSubscribeButtonHandler = require('./handlers/dataset_subscribe_button');
-
-const DATASET_SUBSCRIBE_ACTION = 'dataset_subscribe_button';
+const searchTermButtonHandler = require('./handlers/search/search_term_button');
+const moreTermsButtonHandler = require('./handlers/search/more_terms_button');
 
 const ACTIONS_HANDLER_MAP = {
-    'dataset_subscribe_button' : datasetSubscribeButtonHandler
+    'authorization_request.accept' : authorizationRequestActionButtonsHandler,
+    'authorization_request.cancel' : authorizationRequestActionButtonsHandler,
+    'authorization_request.reject' : authorizationRequestActionButtonsHandler,
+    'clear_search_results_button' : clearSearchResultsButton,
+    'dataset_subscribe_button' : datasetSubscribeButtonHandler,
+    'more_terms_button' : moreTermsButtonHandler,
+    'search_term_button' : searchTermButtonHandler,
+}
+
+const getHandler = (actionId) => {
+    return ACTIONS_HANDLER_MAP[actionId];
 }
 
 module.exports = { 
-    ACTIONS_HANDLER_MAP,
-    DATASET_SUBSCRIBE_ACTION
+    getHandler,
 };

--- a/server/services/actions/handlers/authorization_request_action_buttons.js
+++ b/server/services/actions/handlers/authorization_request_action_buttons.js
@@ -1,0 +1,42 @@
+/*
+ * data.world Slack Application
+ * Copyright 2018 data.world, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This product includes software developed at
+ * data.world, Inc. (http://data.world/).
+ */
+const { handleDatasetRequestAction } = require('../../../controllers/commands/request')
+const handle = async (payload, action, user) => {
+    // Handle 
+    const { requestid, agentid, datasetid } = JSON.parse(action.value)
+    await handleDatasetRequestAction({
+      channelid: payload.channel.id,
+      userid: payload.user.id,
+      triggerid: payload.trigger_id,
+      responseUrl: payload.response_url,
+      message: payload.message,
+      blockid: action.block_id,
+      actionid: action.action_id,
+      requestid,
+      agentid,
+      datasetid,
+      dwAccessToken: user.dwAccessToken,
+    });
+};
+
+// Visible for testing
+module.exports = {
+    handle
+};

--- a/server/services/actions/handlers/search/clear_search_results_button.js
+++ b/server/services/actions/handlers/search/clear_search_results_button.js
@@ -1,0 +1,30 @@
+/*
+ * data.world Slack Application
+ * Copyright 2018 data.world, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This product includes software developed at
+ * data.world, Inc. (http://data.world/).
+ */
+const searchService = require('../../../search');
+
+const handle = async (payload, action, user) => {
+    // Handle 
+    await searchService.sendDefaultSearchHomeView(user.slackId, user.teamId);
+};
+
+// Visible for testing
+module.exports = {
+    handle
+};

--- a/server/services/actions/handlers/search/more_terms_button.js
+++ b/server/services/actions/handlers/search/more_terms_button.js
@@ -1,0 +1,44 @@
+/*
+ * data.world Slack Application
+ * Copyright 2018 data.world, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This product includes software developed at
+ * data.world, Inc. (http://data.world/).
+ */
+const searchService = require('../../../search');
+const { getBotAccessTokenForTeam } = require('../../../../helpers/tokens');
+const slack = require('../../../../api/slack');
+
+const handle = async (payload, action, user) => {
+    // Handle 
+    const { value } = action;
+    const { blocks } = payload.view;
+
+    const [searchTerm, nextPage] = value.split(" ");
+
+    if (searchTerm && nextPage) {
+        const resultBlocks = await searchService.getSearchBlocks(user.dwAccessToken, searchTerm, 3, nextPage);
+        if (resultBlocks) {
+            const { botToken } = await getBotAccessTokenForTeam(user.teamId);
+            const [ searchBox, searchButton ] = blocks;
+            await slack.publishAppHomeView(botToken, user.slackId, [searchBox, searchButton, ...resultBlocks]);
+        }
+    }
+};
+
+// Visible for testing
+module.exports = {
+    handle
+};

--- a/server/services/actions/handlers/search/search_term_button.js
+++ b/server/services/actions/handlers/search/search_term_button.js
@@ -1,0 +1,53 @@
+/*
+ * data.world Slack Application
+ * Copyright 2018 data.world, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This product includes software developed at
+ * data.world, Inc. (http://data.world/).
+ */
+const searchService = require('../../../search');
+const { getBotAccessTokenForTeam } = require('../../../../helpers/tokens');
+const slack = require('../../../../api/slack');
+
+const handle = async (payload, action, user) => {
+    // Handle 
+    const searchInputId = 'search-term-input-box';
+    const { view } = payload;
+    const { state, blocks } = view;
+
+    const stateValues = state.values;
+    let searchTerm = null;
+
+    for (const key in stateValues) {
+        if (stateValues[key][searchInputId]) {
+            searchTerm = stateValues[key][searchInputId].value;
+            break;
+        }
+    }
+    
+    if (searchTerm) {
+        const resultBlocks = await searchService.getSearchBlocks(user.dwAccessToken, searchTerm, 3, null);
+        if (resultBlocks) {
+            const { botToken } = await getBotAccessTokenForTeam(user.teamId);
+            const [ searchBox, searchButton ] = blocks;
+            await slack.publishAppHomeView(botToken, user.slackId, [searchBox, searchButton, ...resultBlocks]);
+        }
+    }
+};
+
+// Visible for testing
+module.exports = {
+    handle
+};

--- a/server/services/search.js
+++ b/server/services/search.js
@@ -1,0 +1,159 @@
+/*
+ * data.world Slack Application
+ * Copyright 2018 data.world, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This product includes software developed at
+ * data.world, Inc. (http://data.world/).
+ */
+
+const lang = require('lodash/lang')
+
+const dataworld = require('../api/dataworld')
+const helper = require('../helpers/helper')
+const slack = require('../api/slack')
+const moment = require("moment");
+
+// data.world command format
+const dwDomain = helper.DW_DOMAIN
+
+const getTimestamp = time => {
+  const offset = moment(
+    time,
+    "YYYY-MM-DDTHH:mm:ss.SSSSZ"
+  ).utcOffset();
+  const ts = moment(time, "YYYY-MM-DDTHH:mm:ss.SSSSZ")
+    .utcOffset(offset)
+    .unix();
+  return ts;
+};
+
+// This method handles subscription to projects and datasets
+const searchTerm = async (token, query, size, responseUrl) => {
+  try {
+    const { data } = await dataworld.searchTerm(token, query, size);
+    if (data.records.length) {
+      const term = data.records[0];
+      const ownerResponse = await dataworld.getDWUser(token, term.owner);
+      const owner = ownerResponse.data;
+      const serverBaseUrl = 'https://major-cougar-adequately.ngrok-free.app';
+
+      const ts = getTimestamp(term.updated);
+      const createdTs = getTimestamp(term.created);
+
+      const blocks = [
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": `*<http://${dwDomain}/${owner.id}|${owner.displayName}>*\n\n<${term.resourceLink}|${term.title}>\n\n\`\`\`${term.description}\`\`\`\n`
+          },
+          "fields": [
+            {
+              "type": "mrkdwn",
+              "text": `*Status:*\n ${term.assetStatus?.assetStatusLabel||'Unknown'}`
+            },
+            {
+              "type": "mrkdwn",
+              "text": `*Category:*\n ${term.category||'Unknown'}`
+            },
+            {
+              "type": "mrkdwn",
+              "text": `*Last Update:*\n <!date^${ts}^  {date_short_pretty} at {time}|Unknown>`
+            },
+            {
+              "type": "mrkdwn",
+              "text": `*Created:*\n <!date^${createdTs}^  {date_short_pretty} at {time}|Unknown>`
+            }
+          ],
+          "accessory": {
+            "type": "image",
+            "image_url": `${serverBaseUrl}/assets/dataset.png`,
+            "alt_text": "avatar"
+          }
+        },
+      {
+        "type": "context",
+        "elements": [
+          {
+            "type": "image",
+            "image_url": `${serverBaseUrl}/assets/dataset.png`,
+            "alt_text": "Business Term"
+          },
+          {
+            "type": "mrkdwn",
+            "text": `${term.owner}/${term.id}`
+          }
+        ]
+      },
+        {
+          "type": "actions",
+          "elements": [
+            {
+              "type": "button",
+              "text": {
+                "type": "plain_text",
+                "text": "View term :zap:",
+              },
+              "url": term.resourceLink
+            }
+          ]
+        }
+      ];
+    
+      await sendSlackMessage(
+        responseUrl,
+        `Found a matching term!`,
+        blocks
+      );
+    } else {
+      await sendSlackMessage(
+        responseUrl,
+        `No matching term found!`,
+      )
+    }
+  } catch (error) {
+    // TODO: Move to message service or slack service 
+    console.warn('Search term request failure : ', error.message)
+    await sendSlackMessage(
+      responseUrl,
+      `Search term request failed, try again later.`,
+    )
+  }
+}
+
+const sendSlackMessage = async (
+  responseUrl,
+  message,
+  blocks,
+  replaceOriginal,
+  deleteOriginal,
+) => {
+  let data = { text: message }
+  if (blocks && !lang.isEmpty(blocks)) {
+    data.blocks = blocks
+  }
+  data.replace_original = replaceOriginal ? replaceOriginal : true
+  data.delete_original = deleteOriginal ? deleteOriginal : true
+  try {
+    await slack.sendResponse(responseUrl, data)
+  } catch (error) {
+    console.error('Failed to send message to slack', error.message)
+  }
+}
+
+// Visible for testing
+module.exports = {
+  searchTerm
+}


### PR DESCRIPTION
- Adds support for `search-term` slash command.
- Add support for terms search from new  app home tab.
- Improves how actions are defined and handle by introducing an `action-provider` for registering actions and handlers.
- Refactor all supported actions to use the new `action-provider`
- Replaced different implementations of `sendSlackBlock`, `sendSlackBlocks` and `sendSlackMessage` with  more generic `sendResponseMessageAndBlocks(...)` 